### PR TITLE
test: establish a testing strategy (local fast tests + CI smoke)

### DIFF
--- a/.claude/hooks/unit-test.mjs
+++ b/.claude/hooks/unit-test.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/**
+ * Unit Test Hook (PostToolUse / Edit|Write)
+ *
+ * Runs the fast unit lane (`pnpm test:run`) after editing a source file or a
+ * co-located spec, giving sub-second feedback while editing. Silent on success;
+ * surfaces a short failure tail as NON-blocking context when a spec breaks (it
+ * informs rather than aborting the edit). Tier 1 of the testing strategy — see
+ * `.claude/rules/tests.md`.
+ */
+
+import { readFileSync } from 'fs'
+import { spawnSync } from 'child_process'
+
+let input
+try {
+  input = JSON.parse(readFileSync(0, 'utf-8'))
+} catch {
+  process.exit(0)
+}
+
+// Claude Code nests the path under tool_input.file_path; tolerate a top-level fallback.
+const filePath = input?.tool_input?.file_path ?? input?.filePath ?? ''
+const projectDir = process.env.CLAUDE_PROJECT_DIR || ''
+const rel = filePath.startsWith(projectDir + '/') ? filePath.slice(projectDir.length + 1) : filePath
+
+// Co-located specs live under src/ (`*.test.ts(x)` included). Skip Ladle stories
+// (not covered by the unit lane) and anything outside src/.
+if (!/^src\/.*\.(ts|tsx)$/.test(rel) || /\.stories\.(ts|tsx)$/.test(rel)) {
+  process.exit(0)
+}
+
+const res = spawnSync('pnpm', ['test:run'], {
+  cwd: projectDir,
+  encoding: 'utf-8',
+  timeout: 60_000,
+})
+
+if (res.status === 0) {
+  process.exit(0)
+}
+
+const output = `${res.stdout || ''}${res.stderr || ''}`.split('\n').slice(-30).join('\n').trim()
+
+// Non-blocking: report the failure as context so it's visible without aborting
+// the edit. `continue: true` lets the session proceed.
+console.log(
+  JSON.stringify({
+    continue: true,
+    additionalContext: `Unit tests failed after editing ${rel}:\n\n${output}\n\nRun \`pnpm test:run\` to see the full output.`,
+  }),
+)
+process.exit(0)

--- a/.claude/hooks/unit-test.mjs
+++ b/.claude/hooks/unit-test.mjs
@@ -32,12 +32,15 @@ if (!/^src\/.*\.(ts|tsx)$/.test(rel) || /\.stories\.(ts|tsx)$/.test(rel)) {
 }
 
 const res = spawnSync('pnpm', ['test:run'], {
-  cwd: projectDir,
+  cwd: projectDir || process.cwd(),
   encoding: 'utf-8',
   timeout: 60_000,
 })
 
-if (res.status === 0) {
+// status === 0 → green. status === null → timed out or couldn't spawn (not a
+// test failure) — stay silent rather than crying wolf. Only a real non-zero
+// exit means specs failed.
+if (res.status === 0 || res.status === null) {
   process.exit(0)
 }
 

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -35,8 +35,9 @@ sneak it in.
 - **Co-locate** specs next to the code they cover: `Foo.tsx` → `Foo.test.tsx`,
   `store.ts` → `store.test.ts`. Smoke specs are the only ones under `tests/`.
 - **Import explicitly** from `vitest` (`import { describe, it, expect, vi }`) and
-  use `it` (not `test`). `globals: true` is set, but explicit imports keep the
-  files honest under the type-checker.
+  use `it` in the unit lane (the smoke specs keep `test`/`test.skipIf`).
+  `globals: true` is set, but explicit imports keep the files honest under the
+  type-checker.
 - **Fixtures**: reuse the schema-typed Ladle mocks (`src/mocks/`) and inline
   small factory objects in the spec. Don't add a `tests/fixtures/` dump — keep
   fixtures next to the assertions that use them.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -1,0 +1,55 @@
+# Testing
+
+Two lanes, kept separate so the fast one never touches the network:
+
+| Lane      | Config                    | Command                  | Runs                                   |
+| --------- | ------------------------- | ------------------------ | -------------------------------------- |
+| **Unit**  | `vitest.config.ts`        | `pnpm test` / `test:run` | Co-located `src/**/*.test.ts(x)`, node |
+| **Smoke** | `vitest.smoke.config.ts`  | `pnpm test:smoke`        | `tests/smoke/**`, fetch vs CF preview  |
+
+- `pnpm test` — watch (inner loop). `pnpm test:run` — one-shot (CI + the pre-PR
+  gate + the PostToolUse hook). `pnpm test:smoke` — needs `PREVIEW_URL`; skips
+  gracefully without it.
+- CI gate runs `lint + typecheck + test:run + build + ladle:build`. The smoke job
+  runs separately against the deployed Cloudflare preview.
+
+## Decision: node-only (no jsdom / Testing Library)
+
+Mirrors WeMeditateWeb. The unit lane runs in the `node` environment. There is
+**no jsdom and no `@testing-library/react`**. Cover:
+
+- **Logic & contracts** — zod schemas (`src/types/`), zustand stores
+  (`src/config/store.ts`), i18n config (`src/config/i18n-options.ts`), the api
+  interceptor (`src/config/api/fetch.ts`).
+- **Presentational components** — assert the SSR output with
+  `renderToStaticMarkup` from `react-dom/server` (see
+  `src/components/atoms/Icons/Icons.test.tsx` for the template). Hover, portals,
+  focus, and map interaction belong in Ladle / the browser, not here.
+
+Add `jsdom` + Testing Library only if a component genuinely needs DOM/interaction
+coverage that SSR markup can't express — and add it as its own decision, don't
+sneak it in.
+
+## Conventions
+
+- **Co-locate** specs next to the code they cover: `Foo.tsx` → `Foo.test.tsx`,
+  `store.ts` → `store.test.ts`. Smoke specs are the only ones under `tests/`.
+- **Import explicitly** from `vitest` (`import { describe, it, expect, vi }`) and
+  use `it` (not `test`). `globals: true` is set, but explicit imports keep the
+  files honest under the type-checker.
+- **Fixtures**: reuse the schema-typed Ladle mocks (`src/mocks/`) and inline
+  small factory objects in the spec. Don't add a `tests/fixtures/` dump — keep
+  fixtures next to the assertions that use them.
+- **Mock at the boundary** with `vi.mock` + `vi.hoisted` (see
+  `src/config/api/fetch.test.ts`): mock `axios` / `@/config/i18n`, not our own
+  logic. Don't test NextUI / react-map-gl / library internals — only *our*
+  contracts.
+
+## Type-checking & the edit-loop hook
+
+- Co-located specs are under `src/`, so the app project (`tsconfig.json`) already
+  type-checks them. `tests/**` and `scripts/**` are checked by
+  `tsconfig.test.json` (the second half of `pnpm typecheck`).
+- A PostToolUse hook (`.claude/hooks/unit-test.mjs`) runs `pnpm test:run` after
+  editing a `src/**/*.{ts,tsx}` file and reports failures as non-blocking
+  context. Keep the lane fast (< ~5s) so this stays painless.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -131,6 +131,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck.mjs"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/unit-test.mjs"
           }
         ]
       }

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -90,7 +90,7 @@ edit; fix surfaced type errors before committing.
 Run the lean local gate:
 
 ```bash
-.claude/skills/implement-issue/scripts/validate.sh          # lint + typecheck
+.claude/skills/implement-issue/scripts/validate.sh          # lint + typecheck + unit
 .claude/skills/implement-issue/scripts/validate.sh --full   # + production build (CI parity)
 ```
 
@@ -143,9 +143,10 @@ gh pr checks <pr-or-branch> --watch
 gh pr checks <pr-or-branch>
 ```
 
-CI (`.github/workflows/ci.yml`) runs **lint + typecheck + build**. On a red
-check, fetch logs (`gh run view <run-id> --log-failed`), fix locally, commit,
-push, re-watch until green.
+CI (`.github/workflows/ci.yml`) runs **lint + typecheck + test:run + build**
+(plus `ladle:build`, and a separate smoke job). On a red check, fetch logs
+(`gh run view <run-id> --log-failed`), fix locally, commit, push, re-watch until
+green.
 
 ### 13. Report
 
@@ -170,9 +171,11 @@ need manual/visual verification (UI screenshots, map interaction).
 - **Vague issue** — stop at step 3 and ask; don't invent acceptance criteria.
 - **Existing PR** — `gh pr list --search "in:title <keyword>"` before branching;
   ask whether to extend or open new.
-- **No test suite** — there are no tests yet; the gate is lint + typecheck +
-  build. For behavioral changes, verify in the running widget (Playwright MCP)
-  and describe the manual check in the PR.
+- **Tests** — a fast node-only unit lane (`pnpm test:run`, co-located
+  `src/**/*.test.ts(x)`) runs on the gate; add specs for new logic/contracts
+  (schemas, stores, helpers, the api interceptor). For behavioral/UI changes the
+  lane can't cover, verify in the running widget (Playwright MCP) and describe
+  the manual check in the PR. See `.claude/rules/tests.md`.
 
 ## References
 

--- a/.claude/skills/implement-issue/scripts/validate.sh
+++ b/.claude/skills/implement-issue/scripts/validate.sh
@@ -2,11 +2,11 @@
 #
 # Validate that the current branch is ready to open a PR.
 #
-# Default (lean local gate): lint + typecheck. Fast feedback.
-# --full: reproduce CI locally — lint + typecheck + production build.
+# Default (lean local gate): lint + typecheck + unit tests. Fast feedback.
+# --full: reproduce CI locally — + the production build.
 #
 # Usage:
-#   .claude/skills/implement-issue/scripts/validate.sh           # lint + typecheck
+#   .claude/skills/implement-issue/scripts/validate.sh           # lint + typecheck + unit
 #   .claude/skills/implement-issue/scripts/validate.sh --full    # + pnpm build
 
 set -u
@@ -36,6 +36,15 @@ fi
 echo "✓ Typecheck passed"
 echo
 
+echo "=== Unit tests ==="
+if ! pnpm test:run; then
+  echo
+  echo "❌ Unit tests failed. Fix them before continuing."
+  exit 1
+fi
+echo "✓ Unit tests passed"
+echo
+
 if [[ "$MODE" == "--full" ]]; then
   echo "=== Build (CI parity) ==="
   if ! pnpm build; then
@@ -46,8 +55,8 @@ if [[ "$MODE" == "--full" ]]; then
   echo "✓ Build passed"
   echo
 else
-  echo "ℹ Lean gate only (lint + typecheck). Run --full to also reproduce the"
-  echo "  production build (CI runs lint + typecheck + build on the PR)."
+  echo "ℹ Lean gate only (lint + typecheck + unit). Run --full to also reproduce"
+  echo "  the production build (CI runs lint + typecheck + test:run + build)."
   echo
 fi
 

--- a/.claude/skills/pr-prep/SKILL.md
+++ b/.claude/skills/pr-prep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-prep
-description: Pre-PR validation — runs the lean local gate (lint + typecheck) by default, with --full to reproduce the CI checks (lint + typecheck + production build) locally. Use before opening or marking a PR ready for review.
+description: Pre-PR validation — runs the lean local gate (lint + typecheck + unit tests) by default, with --full to also reproduce the CI production build locally. Use before opening or marking a PR ready for review.
 allowed-tools: Bash, Read, Grep
 ---
 
@@ -8,18 +8,20 @@ allowed-tools: Bash, Read, Grep
 
 Validates that the current branch is PR-ready.
 
-| Gate                | Command                              | Where                          |
-| ------------------- | ------------------------------------ | ------------------------------ |
-| **Lean (default)**  | `pnpm lint && pnpm typecheck`        | This skill, locally (fast)     |
-| **Full (`--full`)** | + `pnpm build`                       | Mirrors CI (`ci.yml`)          |
+| Gate                | Command                                        | Where                      |
+| ------------------- | ---------------------------------------------- | -------------------------- |
+| **Lean (default)**  | `pnpm lint && pnpm typecheck && pnpm test:run` | This skill, locally (fast) |
+| **Full (`--full`)** | + `pnpm build`                                 | Mirrors CI (`ci.yml`)      |
 
-There is no test suite yet, so CI's gate is **lint + typecheck + build**. When a
-test suite is added, wire it in here and in `ci.yml`.
+CI's gate is **lint + typecheck + test:run + build** (plus `ladle:build`, and a
+separate smoke job against the Cloudflare preview). The lean gate runs the fast
+node-only unit lane; `--full` adds the production build. See
+`.claude/rules/tests.md`.
 
 ## Quick start
 
 ```bash
-.claude/skills/pr-prep/check.sh          # lint + typecheck
+.claude/skills/pr-prep/check.sh          # lint + typecheck + unit
 .claude/skills/pr-prep/check.sh --full   # + pnpm build (CI parity)
 ```
 
@@ -27,9 +29,10 @@ test suite is added, wire it in here and in `ci.yml`.
 
 1. **Lint passes**: `pnpm lint`
 2. **Types check**: `pnpm typecheck`
-3. **Build** (for build-affecting changes — deps, vite/ts config, entry points):
+3. **Unit tests pass**: `pnpm test:run`
+4. **Build** (for build-affecting changes — deps, vite/ts config, entry points):
    `pnpm build`
-4. **Visual check** (UI / map changes): run `pnpm dev` and verify in the widget,
+5. **Visual check** (UI / map changes): run `pnpm dev` and verify in the widget,
    or drive it with the Playwright MCP and capture a screenshot.
 
 ## When `--full` matters
@@ -48,6 +51,7 @@ Include a Verification section (CI is the source of truth):
 
 - Lint: ✓ No errors
 - Types: ✓ Clean
+- Tests: ✓ Unit lane green
 - Build: ✓ Success — or "N/A — no build-affecting changes"
 ```
 

--- a/.claude/skills/pr-prep/check.sh
+++ b/.claude/skills/pr-prep/check.sh
@@ -2,13 +2,14 @@
 #
 # Pre-PR validation.
 #
-# Default (lean gate): lint + typecheck. Fast feedback before opening a PR.
-# --full: reproduce CI locally — lint + typecheck + production build.
+# Default (lean gate): lint + typecheck + unit tests. Fast feedback before a PR.
+# --full: reproduce CI locally — + the production build.
 #
-# CI (.github/workflows/ci.yml) is the source of truth: lint + typecheck + build.
+# CI (.github/workflows/ci.yml) is the source of truth:
+# lint + typecheck + test:run + build.
 #
 # Usage:
-#   .claude/skills/pr-prep/check.sh            # lint + typecheck
+#   .claude/skills/pr-prep/check.sh            # lint + typecheck + unit
 #   .claude/skills/pr-prep/check.sh --full     # + pnpm build
 
 set -u
@@ -38,6 +39,15 @@ fi
 echo "✓ Typecheck passed"
 echo
 
+echo "=== Unit tests ==="
+if ! pnpm test:run; then
+  echo
+  echo "❌ Unit tests failed. Fix them before continuing."
+  exit 1
+fi
+echo "✓ Unit tests passed"
+echo
+
 if [[ "$MODE" == "--full" ]]; then
   echo "=== Build (CI parity) ==="
   if ! pnpm build; then
@@ -48,8 +58,8 @@ if [[ "$MODE" == "--full" ]]; then
   echo "✓ Build passed"
   echo
 else
-  echo "ℹ Lean gate only (lint + typecheck). Use --full to also run the"
-  echo "  production build. CI runs lint + typecheck + build on the PR."
+  echo "ℹ Lean gate only (lint + typecheck + unit). Use --full to also run the"
+  echo "  production build. CI runs lint + typecheck + test:run + build on the PR."
   echo
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck
+      - run: pnpm test:run # unit lane — smoke specs are excluded in vitest.config.ts
       - run: pnpm build
       - run: pnpm ladle:build # fail the gate on broken component stories
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,17 +47,22 @@ embeddable entry is `src/Widget.tsx` (demo in `demo.html`).
 pnpm dev          # Vite dev server (http://localhost:5173)
 pnpm build        # tsc (typecheck) + vite build → dist/
 pnpm preview      # serve the production build locally
-pnpm typecheck    # tsc --noEmit (no build output)
+pnpm typecheck    # tsc --noEmit (app + tests/scripts via tsconfig.test.json)
 pnpm lint         # eslint . (report only)
 pnpm lint:fix     # eslint . --fix (auto-fix + Prettier)
+pnpm test         # vitest watch (fast unit lane)
+pnpm test:run     # vitest run (one-shot — CI + pre-PR gate)
+pnpm test:smoke   # smoke specs vs the Cloudflare preview (needs PREVIEW_URL)
 pnpm ladle        # Ladle component previews (http://localhost:61000)
 pnpm ladle:build  # static Ladle build (CI gate — broken stories fail)
 ```
 
-There is **no unit/component test suite yet** (a `test:smoke` vitest spec runs
-against the Cloudflare preview). CI (`.github/workflows/ci.yml`) gates PRs on
-lint + typecheck + build + `ladle:build`. If you add tests, wire them into CI
-and the `pr-prep` skill.
+Two test lanes (see `.claude/rules/tests.md`): a **fast node-only unit lane**
+(co-located `src/**/*.test.ts(x)`, no jsdom — assert components via
+`renderToStaticMarkup`) and a **smoke lane** (`tests/smoke/`, fetch-based against
+the Cloudflare preview). CI (`.github/workflows/ci.yml`) gates PRs on
+lint + typecheck + **test:run** + build + `ladle:build`; the smoke job runs
+separately. A PostToolUse hook runs the unit lane on `src/**` edits.
 
 ## Code quality
 
@@ -112,6 +117,9 @@ public/locales/<lng>/ # translation JSON (en, fr, … hand-maintained)
   barrel per tier; prefer NextUI built-ins + `tailwind-variants`
   over hand-rolled styled components. See `DESIGN_SYSTEM.md`, `STORYBOOK.md`, and
   `.claude/rules/components.md`. Preview components with `pnpm ladle`.
+- **Tests**: node-only Vitest, co-located `src/**/*.test.ts(x)`; assert
+  components via `renderToStaticMarkup` (no jsdom). Run `pnpm test`. See
+  `.claude/rules/tests.md`.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ public-hoist-pattern[]=*@nextui-org/*
 
 After modifying the `.npmrc` file, you need to run `pnpm install` again to ensure that the dependencies are installed correctly.
 
+### Testing
+
+```bash
+pnpm test         # fast unit lane (Vitest, watch)
+pnpm test:run     # unit lane, one-shot (CI + pre-PR gate)
+pnpm test:smoke   # smoke specs vs the Cloudflare preview (needs PREVIEW_URL)
+```
+
+The unit lane is node-only and co-located (`src/**/*.test.ts(x)`). See
+[`.claude/rules/tests.md`](.claude/rules/tests.md) for the testing strategy.
+
 ## License
 
 Licensed under the [MIT license](https://github.com/nextui-org/vite-template/blob/main/LICENSE).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "vitest",
+    "test:run": "vitest run",
     "test:smoke": "vitest run --config vitest.smoke.config.ts tests/smoke",
     "ladle": "ladle serve",
     "ladle:build": "ladle build",

--- a/src/components/atoms/Icons/Icons.test.tsx
+++ b/src/components/atoms/Icons/Icons.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+
+import { CloseIcon } from '.'
+
+// Node-only component test (mirrors WeMeditateWeb): no jsdom / Testing Library.
+// Presentational components are asserted via their SSR markup with
+// renderToStaticMarkup — this file is the template for component coverage in
+// this repo (see `.claude/rules/tests.md`). Hover/portal/interaction behaviour
+// belongs in Ladle and the browser, not here.
+
+describe('icon components', () => {
+  it('renders an accessible, presentational svg with a path', () => {
+    const html = renderToStaticMarkup(<CloseIcon />)
+
+    expect(html).toContain('<svg')
+    expect(html).toContain('role="presentation"')
+    expect(html).toContain('aria-hidden="true"')
+    expect(html).toContain('<path')
+  })
+
+  it('forwards the size prop to the rendered svg', () => {
+    const html = renderToStaticMarkup(<CloseIcon size={48} />)
+
+    expect(html).toContain('width="48"')
+    expect(html).toContain('height="48"')
+  })
+})

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import atlasAuth from './auth'
+
+import './fetch' // importing registers the request interceptor as a side effect
+
+// The axios client attaches auth + locale to *every* request via one interceptor
+// (so individual fetchers don't have to). We mock axios to capture that
+// interceptor and assert what it does, and mock i18n so importing fetch.ts
+// doesn't boot the real HTTP backend / language detector.
+//
+// vi.hoisted runs before the hoisted vi.mock factories, so `use` is already a
+// spy when fetch.ts calls client.interceptors.request.use(...).
+const { use } = vi.hoisted(() => ({ use: vi.fn() }))
+
+vi.mock('axios', () => ({
+  default: { create: () => ({ interceptors: { request: { use } } }) },
+}))
+vi.mock('@/config/i18n', () => ({ default: { resolvedLanguage: 'fr' } }))
+
+type AxiosRequest = { headers: Record<string, string>; params?: Record<string, unknown> }
+const interceptor = use.mock.calls[0][0] as (req: AxiosRequest) => AxiosRequest
+
+describe('api request interceptor', () => {
+  it('attaches the bearer token and resolved locale to every request', () => {
+    atlasAuth.apiKey = 'test-key-123'
+
+    const request = interceptor({ headers: {} })
+
+    expect(request.headers['Authorization']).toBe('Bearer test-key-123')
+    expect(request.params?.locale).toBe('fr')
+  })
+
+  it('preserves existing query params while adding the locale', () => {
+    atlasAuth.apiKey = 'k'
+
+    const request = interceptor({ headers: {}, params: { latitude: 52 } })
+
+    expect(request.params).toMatchObject({ latitude: 52, locale: 'fr' })
+  })
+})

--- a/src/config/i18n-options.test.ts
+++ b/src/config/i18n-options.test.ts
@@ -1,0 +1,34 @@
+import { createInstance } from 'i18next'
+import { describe, it, expect, beforeAll } from 'vitest'
+
+import { i18nSharedOptions } from './i18n-options'
+
+// i18n-options is the side-effect-free config shared by the app's HTTP-backed
+// instance (i18n.ts) and the Ladle story instance, so its Ruby-style %{...}
+// interpolation (shared with the Rails backend that owns the locale JSON) and
+// its en fallback can't drift between the two. We boot a standalone instance
+// with inline resources — no HTTP backend — to lock that contract.
+
+let i18n: ReturnType<typeof createInstance>
+
+beforeAll(async () => {
+  i18n = createInstance()
+  await i18n.init({
+    ...i18nSharedOptions,
+    lng: 'fr',
+    resources: {
+      en: { common: { greeting: 'Hello %{name}', onlyEnglish: 'English only' } },
+      fr: { common: { greeting: 'Bonjour %{name}' } },
+    },
+  })
+})
+
+describe('i18nSharedOptions', () => {
+  it('interpolates Ruby-style %{var} placeholders, not the i18next default {{var}}', () => {
+    expect(i18n.t('greeting', { name: 'Atlas' })).toBe('Bonjour Atlas')
+  })
+
+  it('falls back to en for keys missing in the active language', () => {
+    expect(i18n.t('onlyEnglish')).toBe('English only')
+  })
+})

--- a/src/config/store.test.ts
+++ b/src/config/store.test.ts
@@ -1,0 +1,72 @@
+import type { Feature } from 'geojson'
+
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { useNavigationState, useSearchState, useViewState } from './store'
+
+// The stores are the single source of truth for map view, navigation history,
+// and search filters. They're plain zustand vanilla stores, so we drive their
+// actions directly via getState() without React. Reset to the initial slice in
+// beforeEach since the module singletons persist between tests.
+
+describe('useViewState', () => {
+  beforeEach(() => {
+    useViewState.setState({
+      latitude: 0,
+      longitude: 0,
+      zoom: 0,
+      selection: null,
+      boundary: undefined,
+    })
+  })
+
+  it('setViewState updates the camera fields', () => {
+    useViewState.getState().setViewState({ latitude: 51.5, longitude: -0.12, zoom: 8 })
+
+    expect(useViewState.getState()).toMatchObject({ latitude: 51.5, longitude: -0.12, zoom: 8 })
+  })
+
+  it('setSelection stores the picked point and setBoundary stores a feature', () => {
+    const boundary: Feature = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [2, 1] },
+      properties: {},
+    }
+
+    useViewState.getState().setSelection({ latitude: 1, longitude: 2, approximate: true })
+    useViewState.getState().setBoundary(boundary)
+
+    const state = useViewState.getState()
+
+    expect(state.selection).toEqual({ latitude: 1, longitude: 2, approximate: true })
+    expect(state.boundary).toBe(boundary)
+  })
+})
+
+describe('useNavigationState', () => {
+  beforeEach(() => {
+    useNavigationState.setState({ previousPath: '', currentPath: '' })
+  })
+
+  it('setCurrentPath shifts the prior path into previousPath', () => {
+    useNavigationState.getState().setCurrentPath('/search')
+    useNavigationState.getState().setCurrentPath('/countries/gb')
+
+    const state = useNavigationState.getState()
+
+    expect(state.previousPath).toBe('/search')
+    expect(state.currentPath).toBe('/countries/gb')
+  })
+})
+
+describe('useSearchState', () => {
+  beforeEach(() => {
+    useSearchState.setState({ onlineOnly: false })
+  })
+
+  it('setOnlineOnly toggles the online-only filter', () => {
+    useSearchState.getState().setOnlineOnly(true)
+
+    expect(useSearchState.getState().onlineOnly).toBe(true)
+  })
+})

--- a/src/types/area.test.ts
+++ b/src/types/area.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+
+import { AreaSchema, AreaSlimSchema } from './area'
+
+import { mockEventSlimList } from '@/mocks/events'
+
+const area = {
+  id: 100,
+  path: '/areas/cambridge',
+  label: 'Cambridge',
+  subtitle: 'East of England',
+  url: 'https://atlas.example/areas/cambridge',
+  parentPath: '/regions/cam',
+  events: mockEventSlimList,
+  latitude: 52.2053,
+  longitude: 0.1218,
+  radius: 5000,
+}
+
+describe('AreaSchema', () => {
+  it('parses an area with its embedded slim events', () => {
+    const parsed = AreaSchema.parse(area)
+
+    expect(parsed.events).toHaveLength(mockEventSlimList.length)
+  })
+
+  it('rejects a non-numeric radius', () => {
+    expect(() => AreaSchema.parse({ ...area, radius: 'wide' })).toThrow()
+  })
+})
+
+describe('AreaSlimSchema', () => {
+  it('parses a slim area with an event count', () => {
+    expect(() =>
+      AreaSlimSchema.parse({
+        id: 100,
+        path: '/areas/cambridge',
+        label: 'Cambridge',
+        eventCount: 3,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/src/types/area.test.ts
+++ b/src/types/area.test.ts
@@ -31,13 +31,13 @@ describe('AreaSchema', () => {
 
 describe('AreaSlimSchema', () => {
   it('parses a slim area with an event count', () => {
-    expect(() =>
-      AreaSlimSchema.parse({
-        id: 100,
-        path: '/areas/cambridge',
-        label: 'Cambridge',
-        eventCount: 3,
-      }),
-    ).not.toThrow()
+    const parsed = AreaSlimSchema.parse({
+      id: 100,
+      path: '/areas/cambridge',
+      label: 'Cambridge',
+      eventCount: 3,
+    })
+
+    expect(parsed.eventCount).toBe(3)
   })
 })

--- a/src/types/client.test.ts
+++ b/src/types/client.test.ts
@@ -4,25 +4,25 @@ import { ClientSchema } from './client'
 
 describe('ClientSchema', () => {
   it('parses a client with a locale and initial path', () => {
-    expect(() =>
-      ClientSchema.parse({
-        name: 'Host Site',
-        domain: 'host.example',
-        locale: 'en',
-        initialPath: '/search',
-      }),
-    ).not.toThrow()
+    const parsed = ClientSchema.parse({
+      name: 'Host Site',
+      domain: 'host.example',
+      locale: 'en',
+      initialPath: '/search',
+    })
+
+    expect(parsed).toMatchObject({ locale: 'en', initialPath: '/search' })
   })
 
   it('allows null locale and initialPath', () => {
-    expect(() =>
-      ClientSchema.parse({
-        name: 'Host Site',
-        domain: 'host.example',
-        locale: null,
-        initialPath: null,
-      }),
-    ).not.toThrow()
+    const parsed = ClientSchema.parse({
+      name: 'Host Site',
+      domain: 'host.example',
+      locale: null,
+      initialPath: null,
+    })
+
+    expect(parsed.locale).toBeNull()
   })
 
   it('rejects a missing domain', () => {

--- a/src/types/client.test.ts
+++ b/src/types/client.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+
+import { ClientSchema } from './client'
+
+describe('ClientSchema', () => {
+  it('parses a client with a locale and initial path', () => {
+    expect(() =>
+      ClientSchema.parse({
+        name: 'Host Site',
+        domain: 'host.example',
+        locale: 'en',
+        initialPath: '/search',
+      }),
+    ).not.toThrow()
+  })
+
+  it('allows null locale and initialPath', () => {
+    expect(() =>
+      ClientSchema.parse({
+        name: 'Host Site',
+        domain: 'host.example',
+        locale: null,
+        initialPath: null,
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects a missing domain', () => {
+    expect(() =>
+      ClientSchema.parse({ name: 'Host Site', locale: null, initialPath: null }),
+    ).toThrow()
+  })
+})

--- a/src/types/country.test.ts
+++ b/src/types/country.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+
+import { CountrySchema, CountrySlimSchema } from './country'
+
+const country = {
+  id: 1,
+  path: '/countries/gb',
+  code: 'GB',
+  label: 'United Kingdom',
+  eventCount: 42,
+  url: 'https://atlas.example/countries/gb',
+  bounds: [-8.65, 49.86, 1.76, 60.86],
+  children: [
+    {
+      id: 10,
+      path: '/regions/cam',
+      type: 'region',
+      label: 'Cambridgeshire',
+      subtitle: null,
+      eventCount: 5,
+    },
+  ],
+}
+
+const countrySlim = {
+  id: 1,
+  path: '/countries/gb',
+  code: 'GB',
+  label: 'United Kingdom',
+  eventCount: 42,
+}
+
+describe('CountrySlimSchema', () => {
+  it('parses a country list entry', () => {
+    expect(() => CountrySlimSchema.parse(countrySlim)).not.toThrow()
+  })
+
+  it('rejects a non-numeric eventCount', () => {
+    expect(() => CountrySlimSchema.parse({ ...countrySlim, eventCount: 'many' })).toThrow()
+  })
+})
+
+describe('CountrySchema', () => {
+  it('parses a country with bounds and children', () => {
+    const parsed = CountrySchema.parse(country)
+
+    expect(parsed.children).toHaveLength(1)
+  })
+
+  it('rejects a bounds tuple of the wrong length', () => {
+    expect(() => CountrySchema.parse({ ...country, bounds: [0, 0, 0] })).toThrow()
+  })
+})

--- a/src/types/country.test.ts
+++ b/src/types/country.test.ts
@@ -32,7 +32,9 @@ const countrySlim = {
 
 describe('CountrySlimSchema', () => {
   it('parses a country list entry', () => {
-    expect(() => CountrySlimSchema.parse(countrySlim)).not.toThrow()
+    const parsed = CountrySlimSchema.parse(countrySlim)
+
+    expect(parsed.code).toBe('GB')
   })
 
   it('rejects a non-numeric eventCount', () => {

--- a/src/types/event.test.ts
+++ b/src/types/event.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+
+import { EventSchema, EventSlimSchema } from './event'
+
+import { mockEvent, mockEventSlim, mockEventSlimList } from '@/mocks/events'
+
+// The fetchers parse every response through these schemas (src/config/api/fetch.ts),
+// so a backend shape change should surface here as a parse error, not a runtime
+// crash deep in the UI. We reuse the Ladle mocks (typed against the same schemas)
+// as the happy-path fixtures and add a raw-wire payload to prove date coercion.
+
+describe('EventSlimSchema', () => {
+  it('parses the slim list fixtures', () => {
+    expect(() => EventSlimSchema.array().parse(mockEventSlimList)).not.toThrow()
+  })
+
+  it('coerces ISO date strings from the wire into Date objects', () => {
+    const parsed = EventSlimSchema.parse({
+      ...mockEventSlim,
+      nextDate: '2026-07-04T09:30:00Z',
+      firstDate: '2026-01-10T09:30:00Z',
+    })
+
+    expect(parsed.nextDate).toBeInstanceOf(Date)
+    expect(parsed.firstDate.toISOString()).toBe('2026-01-10T09:30:00.000Z')
+  })
+
+  it('rejects an unknown recurrence type', () => {
+    expect(() =>
+      EventSlimSchema.parse({ ...mockEventSlim, recurrenceType: 'fortnightly' }),
+    ).toThrow()
+  })
+
+  it('rejects a missing required field', () => {
+    expect(() => EventSlimSchema.parse({ ...mockEventSlim, latitude: undefined })).toThrow()
+  })
+})
+
+describe('EventSchema', () => {
+  it('parses the full event fixture (nested timing / location / images)', () => {
+    const parsed = EventSchema.parse(mockEvent)
+
+    expect(parsed.id).toBe(mockEvent.id)
+    expect(parsed.location.countryCode).toBe('GB')
+  })
+
+  it('rejects a two-letter country code that is the wrong length', () => {
+    const bad = { ...mockEvent, location: { ...mockEvent.location, countryCode: 'GBR' } }
+
+    expect(() => EventSchema.parse(bad)).toThrow()
+  })
+
+  it('rejects an image url that is not a valid URL', () => {
+    const bad = { ...mockEvent, images: [{ url: 'not-a-url', thumbnailUrl: 'also-bad' }] }
+
+    expect(() => EventSchema.parse(bad)).toThrow()
+  })
+})

--- a/src/types/event.test.ts
+++ b/src/types/event.test.ts
@@ -11,7 +11,9 @@ import { mockEvent, mockEventSlim, mockEventSlimList } from '@/mocks/events'
 
 describe('EventSlimSchema', () => {
   it('parses the slim list fixtures', () => {
-    expect(() => EventSlimSchema.array().parse(mockEventSlimList)).not.toThrow()
+    const parsed = EventSlimSchema.array().parse(mockEventSlimList)
+
+    expect(parsed).toHaveLength(mockEventSlimList.length)
   })
 
   it('coerces ISO date strings from the wire into Date objects', () => {

--- a/src/types/region.test.ts
+++ b/src/types/region.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+
+import { RegionSchema, RegionSlimSchema } from './region'
+
+const region = {
+  id: 10,
+  path: '/regions/cam',
+  label: 'Cambridgeshire',
+  eventCount: 5,
+  url: 'https://atlas.example/regions/cam',
+  parentPath: '/countries/gb',
+  areas: [{ id: 100, path: '/areas/cambridge', label: 'Cambridge', subtitle: null, eventCount: 3 }],
+  bounds: [-0.5, 52.0, 0.5, 52.5],
+}
+
+describe('RegionSchema', () => {
+  it('parses a region with nested slim areas', () => {
+    const parsed = RegionSchema.parse(region)
+
+    expect(parsed.areas).toHaveLength(1)
+  })
+
+  it('rejects an area child missing its eventCount', () => {
+    const bad = { ...region, areas: [{ id: 100, path: '/areas/cambridge', label: 'Cambridge' }] }
+
+    expect(() => RegionSchema.parse(bad)).toThrow()
+  })
+})
+
+describe('RegionSlimSchema', () => {
+  it('parses a slim region (core fields only)', () => {
+    expect(() =>
+      RegionSlimSchema.parse({
+        id: 10,
+        path: '/regions/cam',
+        label: 'Cambridgeshire',
+        eventCount: 5,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/src/types/region.test.ts
+++ b/src/types/region.test.ts
@@ -29,13 +29,13 @@ describe('RegionSchema', () => {
 
 describe('RegionSlimSchema', () => {
   it('parses a slim region (core fields only)', () => {
-    expect(() =>
-      RegionSlimSchema.parse({
-        id: 10,
-        path: '/regions/cam',
-        label: 'Cambridgeshire',
-        eventCount: 5,
-      }),
-    ).not.toThrow()
+    const parsed = RegionSlimSchema.parse({
+      id: 10,
+      path: '/regions/cam',
+      label: 'Cambridgeshire',
+      eventCount: 5,
+    })
+
+    expect(parsed.id).toBe(10)
   })
 })

--- a/src/types/registration.test.ts
+++ b/src/types/registration.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+
+import { RegistrationSchema } from './registration'
+
+const base = { startingAt: '2026-07-04T09:30:00Z', name: 'Jane Doe', email: 'jane@example.com' }
+
+describe('RegistrationSchema', () => {
+  it('parses a valid registration and coerces the start date', () => {
+    const parsed = RegistrationSchema.parse(base)
+
+    expect(parsed.startingAt).toBeInstanceOf(Date)
+  })
+
+  it('accepts accented names', () => {
+    expect(() => RegistrationSchema.parse({ ...base, name: 'José Müller' })).not.toThrow()
+  })
+
+  it('rejects a name containing digits', () => {
+    expect(() => RegistrationSchema.parse({ ...base, name: 'Agent007' })).toThrow()
+  })
+
+  it('rejects an invalid email', () => {
+    expect(() => RegistrationSchema.parse({ ...base, email: 'not-an-email' })).toThrow()
+  })
+})

--- a/src/types/registration.test.ts
+++ b/src/types/registration.test.ts
@@ -12,7 +12,9 @@ describe('RegistrationSchema', () => {
   })
 
   it('accepts accented names', () => {
-    expect(() => RegistrationSchema.parse({ ...base, name: 'José Müller' })).not.toThrow()
+    const parsed = RegistrationSchema.parse({ ...base, name: 'José Müller' })
+
+    expect(parsed.name).toBe('José Müller')
   })
 
   it('rejects a name containing digits', () => {

--- a/src/types/venue.test.ts
+++ b/src/types/venue.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+
+import { VenueSchema, VenueSlimSchema } from './venue'
+
+import { mockEventSlimList } from '@/mocks/events'
+
+const venue = {
+  id: 8001,
+  path: '/venues/town-hall',
+  label: 'Town Hall',
+  latitude: 52.2053,
+  longitude: 0.1218,
+  url: 'https://atlas.example/venues/town-hall',
+  parentPath: '/areas/cambridge',
+  events: mockEventSlimList,
+}
+
+describe('VenueSchema', () => {
+  it('parses a venue with embedded slim events', () => {
+    const parsed = VenueSchema.parse(venue)
+
+    expect(parsed.events).toHaveLength(mockEventSlimList.length)
+  })
+
+  it('rejects a venue missing its coordinates', () => {
+    expect(() => VenueSchema.parse({ ...venue, latitude: undefined })).toThrow()
+  })
+})
+
+describe('VenueSlimSchema', () => {
+  it('parses a slim venue with an event count', () => {
+    expect(() =>
+      VenueSlimSchema.parse({
+        id: 8001,
+        path: '/venues/town-hall',
+        label: 'Town Hall',
+        latitude: 52.2053,
+        longitude: 0.1218,
+        eventCount: 4,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/src/types/venue.test.ts
+++ b/src/types/venue.test.ts
@@ -29,15 +29,15 @@ describe('VenueSchema', () => {
 
 describe('VenueSlimSchema', () => {
   it('parses a slim venue with an event count', () => {
-    expect(() =>
-      VenueSlimSchema.parse({
-        id: 8001,
-        path: '/venues/town-hall',
-        label: 'Town Hall',
-        latitude: 52.2053,
-        longitude: 0.1218,
-        eventCount: 4,
-      }),
-    ).not.toThrow()
+    const parsed = VenueSlimSchema.parse({
+      id: 8001,
+      path: '/venues/town-hall',
+      label: 'Town Hall',
+      latitude: 52.2053,
+      longitude: 0.1218,
+      eventCount: 4,
+    })
+
+    expect(parsed.eventCount).toBe(4)
   })
 })

--- a/tests/smoke/_helpers/preview.ts
+++ b/tests/smoke/_helpers/preview.ts
@@ -1,0 +1,17 @@
+// Shared helpers for smoke specs that hit the deployed Cloudflare Pages preview.
+//
+// PREVIEW_URL is injected by CI after discovering the preview deployment
+// (scripts/get-cloudflare-preview-url.mjs). When it's absent — local runs,
+// forked PRs without secrets — specs skip rather than fail: guard them with
+// `test.skipIf(skipWithoutPreview)` and only call fetchPreview inside.
+
+/** Base URL of the preview to smoke-test against, trailing slash trimmed. */
+export const PREVIEW_URL = process.env.PREVIEW_URL?.replace(/\/$/, '')
+
+/** True when no preview URL is available — pass to `test.skipIf(...)`. */
+export const skipWithoutPreview = !PREVIEW_URL
+
+/** Fetch a path on the preview. Only call when a preview URL is present. */
+export function fetchPreview(path: string): Promise<Response> {
+  return fetch(`${PREVIEW_URL}${path}`)
+}

--- a/tests/smoke/root.smoke.test.ts
+++ b/tests/smoke/root.smoke.test.ts
@@ -1,20 +1,16 @@
 import { describe, expect, test } from 'vitest'
 
+import { fetchPreview, skipWithoutPreview } from './_helpers/preview'
+
 // Smoke test: does the deployed Cloudflare Pages preview actually serve the app?
 // This is the minimal "is the deploy alive" check — it fetches the root page and
 // asserts the SPA shell is returned. It catches a broken build, a missing
 // `_redirects` fallback, or a dead deploy. Deeper interaction coverage (clicking
 // the map, entity routes, locales) is tracked for follow-up.
-//
-// PREVIEW_URL is injected by CI after discovering the preview deployment. When
-// it's absent (e.g. running locally with nothing to point at), the spec skips
-// rather than failing.
-
-const PREVIEW_URL = process.env.PREVIEW_URL?.replace(/\/$/, '')
 
 describe('root page', () => {
-  test.skipIf(!PREVIEW_URL)('serves the SPA shell at /', async () => {
-    const res = await fetch(`${PREVIEW_URL}/`)
+  test.skipIf(skipWithoutPreview)('serves the SPA shell at /', async () => {
+    const res = await fetchPreview('/')
 
     expect(res.status).toBe(200)
 

--- a/tests/smoke/spa-fallback.smoke.test.ts
+++ b/tests/smoke/spa-fallback.smoke.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+
+// Smoke test: does the Cloudflare Pages preview serve the SPA shell for a deep
+// link that isn't the root? The standalone build uses BrowserRouter, so a direct
+// GET /search only returns the app if the `public/_redirects` fallback
+// (`/* /index.html 200`) is deployed — this guards that fix (from PR #3). The
+// embeddable widget uses HashRouter and doesn't depend on the fallback.
+//
+// PREVIEW_URL is injected by CI after discovering the preview deployment; the
+// spec skips when it's absent (e.g. local runs, forked PRs without secrets).
+
+const PREVIEW_URL = process.env.PREVIEW_URL?.replace(/\/$/, '')
+
+describe('SPA deep-link fallback', () => {
+  test.skipIf(!PREVIEW_URL)('serves the SPA shell at a deep link (/search)', async () => {
+    const res = await fetch(`${PREVIEW_URL}/search`)
+
+    expect(res.status).toBe(200)
+
+    const html = await res.text()
+
+    // Same shell as the root page — _redirects rewrote /search to index.html.
+    expect(html).toContain('id="syatlas"')
+  })
+})

--- a/tests/smoke/spa-fallback.smoke.test.ts
+++ b/tests/smoke/spa-fallback.smoke.test.ts
@@ -1,19 +1,16 @@
 import { describe, expect, test } from 'vitest'
 
+import { fetchPreview, skipWithoutPreview } from './_helpers/preview'
+
 // Smoke test: does the Cloudflare Pages preview serve the SPA shell for a deep
 // link that isn't the root? The standalone build uses BrowserRouter, so a direct
 // GET /search only returns the app if the `public/_redirects` fallback
 // (`/* /index.html 200`) is deployed — this guards that fix (from PR #3). The
 // embeddable widget uses HashRouter and doesn't depend on the fallback.
-//
-// PREVIEW_URL is injected by CI after discovering the preview deployment; the
-// spec skips when it's absent (e.g. local runs, forked PRs without secrets).
-
-const PREVIEW_URL = process.env.PREVIEW_URL?.replace(/\/$/, '')
 
 describe('SPA deep-link fallback', () => {
-  test.skipIf(!PREVIEW_URL)('serves the SPA shell at a deep link (/search)', async () => {
-    const res = await fetch(`${PREVIEW_URL}/search`)
+  test.skipIf(skipWithoutPreview)('serves the SPA shell at a deep link (/search)', async () => {
+    const res = await fetchPreview('/search')
 
     expect(res.status).toBe(200)
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -14,5 +14,5 @@
     "checkJs": true,
     "noImplicitAny": false
   },
-  "include": ["tests", "scripts"]
+  "include": ["tests", "scripts", "vitest.config.ts", "vitest.smoke.config.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  // Type-checks the code the app tsconfig ("include": ["src", ".ladle"]) leaves
+  // out: the smoke specs and the build/CI scripts. Co-located unit specs live
+  // under src/ and are already covered by the app project. Run via the second
+  // half of `pnpm typecheck` (see package.json).
+  //
+  // allowJs + checkJs so the .mjs scripts are checked too; noImplicitAny is
+  // relaxed because those node utilities are intentionally untyped (annotating
+  // every callback param adds noise without catching real bugs).
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noImplicitAny": false
+  },
+  "include": ["tests", "scripts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+// Fast local/unit lane: pure, dependency-light specs co-located with the code
+// they cover (`src/**/*.test.ts(x)`). Node-only — component specs assert SSR
+// markup via `renderToStaticMarkup` rather than booting jsdom (mirrors
+// WeMeditateWeb). See `.claude/rules/tests.md`.
+//
+// `tsconfigPaths` resolves the `@/…` alias the same way Vite does, so specs and
+// the modules they import can use it. Smoke specs hit a deployed preview over
+// the network and live in their own config (vitest.smoke.config.ts) — they're
+// excluded here so `pnpm test:run` never touches the network.
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules', 'dist', 'build', '.ladle', 'tests/smoke/**'],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['**/*.{test,spec}.{ts,tsx}'],
+    // Co-located specs live under src/; smoke specs hit the network and run via
+    // their own config — keep them (and build output) out of the unit lane.
     exclude: ['node_modules', 'dist', 'build', '.ladle', 'tests/smoke/**'],
   },
 })

--- a/vitest.smoke.config.ts
+++ b/vitest.smoke.config.ts
@@ -9,5 +9,9 @@ export default defineConfig({
     environment: 'node',
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // Network round-trips against a real edge deployment — give them room and
+    // retry transient failures rather than flaking the job.
+    retry: 2,
+    bail: 0,
   },
 })


### PR DESCRIPTION
## Summary

Establishes the tiered testing strategy from #4: a **fast node-only unit lane**
for our logic/contracts and an **expanded smoke lane** for the deploy — wired
into the CI gate, the pre-PR gates, and the edit loop.

- Adds a Vitest unit lane (`vitest.config.ts`, `pnpm test` / `test:run`) with
  **37 co-located specs** covering the high-value Tier 1 targets, and grows the
  smoke suite to guard the SPA deep-link fallback.
- Closes the type-check gap (tests + scripts were unchecked) and updates the
  docs/skills that claimed "no test suite yet".

## Changes

By acceptance criterion:

- **Decision recorded** — node-only Vitest, no jsdom/Testing Library (mirrors
  WeMeditateWeb); presentational components assert SSR markup via
  `renderToStaticMarkup`. Captured in `.claude/rules/tests.md`, with
  `src/components/atoms/Icons/Icons.test.tsx` as the template.
- **Unit lane** — `vitest.config.ts` (separate from `vitest.smoke.config.ts`),
  scripts `test` (watch) / `test:run` (one-shot).
- **Tier 1 specs** — zod schemas (every entity + `*Slim` + Client +
  Registration), zustand stores, `i18n-options` `%{var}` interpolation + `en`
  fallback, and the axios request interceptor (Authorization + locale).
- **CI gate** — `pnpm test:run` added: `lint + typecheck + test:run + build +
  ladle:build`.
- **Type-check tests & scripts** — `tsconfig.test.json` (covers `tests/**` +
  `scripts/**`, `allowJs`/`checkJs` for the `.mjs`); `typecheck` now runs both
  projects. Co-located `src/**/*.test.ts(x)` are covered by the app project.
- **Smoke** — `tests/smoke/spa-fallback.smoke.test.ts` (`GET /search` → 200 +
  SPA shell, guards `public/_redirects`) + shared `tests/smoke/_helpers/preview.ts`.
- **Docs/skills** — `CLAUDE.md`, `README.md`, and the `pr-prep` /
  `implement-issue` skills (+ their gate scripts) now run/reference the unit lane.
- **Edit-loop hook** — `.claude/hooks/unit-test.mjs` runs the lane on `src/**`
  edits (non-blocking), mirroring the sy-devs-cms Tier 1 hook.

## Verification

- Lint: ✓ No errors (`pnpm lint`)
- Types: ✓ Clean (`pnpm typecheck` — both projects)
- Tests: ✓ 37 unit specs pass (`pnpm test:run`, ~0.5s); smoke specs skip locally
  (no `PREVIEW_URL`) and run on the CI preview
- Build: ✓ Success (`pnpm build`) + `pnpm ladle:build` — test files are not
  bundled

## Notes for reviewer

- **Fixtures**: per the WeMeditateWeb pattern, fixtures are inline/factory-based
  and the event specs reuse the schema-typed `src/mocks/events.ts` — no separate
  `tests/fixtures/` dir (the issue listed it as optional/cross-cutting).
- **Specs are co-located** under `src/` (not `tests/unit/`), so they're
  type-checked by the app `tsconfig` and excluded from the bundle by Vite.
- `tsconfig.test.json` sets `noImplicitAny: false` so `checkJs` doesn't demand
  annotating the intentionally-untyped `.mjs` build scripts; `.ts` specs under
  `src/` stay strict via the app project.
- Ran `/simplify` (extracted the smoke helper, strengthened weak assertions) and
  `/code-review` (fixed a unit-test-hook timeout edge so a >60s/spawn failure
  isn't misreported as a test failure).

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
