### PR TITLE
refactor(ui): unify dark mode across Ladle and components

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -1,6 +1,7 @@
 import type { GlobalProvider } from '@ladle/react'
 
 import { useEffect } from 'react'
+import { ThemeState, useLadleContext } from '@ladle/react'
 import { MemoryRouter } from 'react-router'
 import { I18nextProvider } from 'react-i18next'
 
@@ -22,24 +23,41 @@ import '@/styles/globals.css'
 // The widget injects its CSS via JS in production, so stories must import
 // globals.css explicitly.
 //
-// Theme: matching WeMeditateWeb, the story canvas is **always light** so the
-// StorySection helper's gray-900 titles stay legible. Dark previews are shown
-// per-section via <StorySection theme="dark">, which applies the `dark` class to
-// its own subtree (so NextUI components there render dark). We force the `light`
-// class here rather than mapping Ladle's theme toggle to the whole canvas.
+// Theme: Ladle's own light/dark/auto toggle drives the whole canvas. We map its
+// active theme onto the root `light`/`dark` class that Tailwind (darkMode:
+// 'class'), NextUI, and useTheme all read — so flipping Ladle's toggle re-themes
+// every story, including the Mapbox basemap (which follows useTheme). `auto`
+// resolves against the OS preference and tracks it live.
 export const Provider: GlobalProvider = ({ children }) => {
+  const { globalState } = useLadleContext()
+  const ladleTheme = globalState.theme
+
   useEffect(() => {
     const root = document.documentElement
 
-    root.classList.add('light')
-    root.classList.remove('dark')
-  }, [])
+    const apply = (dark: boolean) => {
+      root.classList.toggle('dark', dark)
+      root.classList.toggle('light', !dark)
+    }
+
+    if (ladleTheme === ThemeState.Auto) {
+      const media = window.matchMedia('(prefers-color-scheme: dark)')
+      const onChange = (event: MediaQueryListEvent) => apply(event.matches)
+
+      apply(media.matches)
+      media.addEventListener('change', onChange)
+
+      return () => media.removeEventListener('change', onChange)
+    }
+
+    apply(ladleTheme === ThemeState.Dark)
+  }, [ladleTheme])
 
   return (
     <I18nextProvider i18n={storyI18n}>
       <MemoryRouter>
         <Providers>
-          <main className="min-h-screen bg-white p-6 text-gray-900">{children}</main>
+          <main className="min-h-screen bg-background p-6 text-foreground">{children}</main>
         </Providers>
       </MemoryRouter>
     </I18nextProvider>

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -8,6 +8,7 @@ import { I18nextProvider } from 'react-i18next'
 import storyI18n from './i18n'
 
 import Providers from '@/providers'
+import { applyTheme } from '@/hooks/use-theme'
 
 import '@/styles/globals.css'
 
@@ -24,40 +25,35 @@ import '@/styles/globals.css'
 // globals.css explicitly.
 //
 // Theme: Ladle's own light/dark/auto toggle drives the whole canvas. We map its
-// active theme onto the root `light`/`dark` class that Tailwind (darkMode:
-// 'class'), NextUI, and useTheme all read — so flipping Ladle's toggle re-themes
-// every story, including the Mapbox basemap (which follows useTheme). `auto`
-// resolves against the OS preference and tracks it live.
+// active theme onto the root `light`/`dark` class — through the same applyTheme
+// seam useTheme uses — that Tailwind (darkMode: 'class'), NextUI, and useTheme
+// all read, so flipping Ladle's toggle re-themes every story, including the
+// Mapbox basemap (which follows useTheme). `auto` resolves against the OS
+// preference and tracks it live. The canvas background is left to Ladle's own
+// theme so it matches the surrounding chrome.
 export const Provider: GlobalProvider = ({ children }) => {
   const { globalState } = useLadleContext()
   const ladleTheme = globalState.theme
 
   useEffect(() => {
-    const root = document.documentElement
-
-    const apply = (dark: boolean) => {
-      root.classList.toggle('dark', dark)
-      root.classList.toggle('light', !dark)
-    }
-
     if (ladleTheme === ThemeState.Auto) {
       const media = window.matchMedia('(prefers-color-scheme: dark)')
-      const onChange = (event: MediaQueryListEvent) => apply(event.matches)
+      const sync = () => applyTheme(media.matches ? 'dark' : 'light')
 
-      apply(media.matches)
-      media.addEventListener('change', onChange)
+      sync()
+      media.addEventListener('change', sync)
 
-      return () => media.removeEventListener('change', onChange)
+      return () => media.removeEventListener('change', sync)
     }
 
-    apply(ladleTheme === ThemeState.Dark)
+    applyTheme(ladleTheme === ThemeState.Dark ? 'dark' : 'light')
   }, [ladleTheme])
 
   return (
     <I18nextProvider i18n={storyI18n}>
       <MemoryRouter>
         <Providers>
-          <main className="min-h-screen bg-background p-6 text-foreground">{children}</main>
+          <main className="min-h-screen p-6 text-foreground">{children}</main>
         </Providers>
       </MemoryRouter>
     </I18nextProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import MapLayout from './layouts/map'
 import api from './config/api'
 
 import { regionPath } from '@/lib/shape'
-import { initTheme } from '@/hooks/use-theme'
 import { ErrorFallback, LoadingFallback } from '@/components/atoms'
 import EventPage from '@/pages/event'
 import VenuePage from '@/pages/venue'
@@ -32,11 +31,6 @@ type AppProps = {
 }
 
 export default function App(props: AppProps) {
-  // Restore the persisted (or default) theme once on mount. Afterwards useTheme
-  // and ThemeSwitch keep the root class in sync; the Ladle decorator drives it
-  // there instead (stories don't render App).
-  useEffect(() => initTheme(), [])
-
   return (
     <Providers>
       <Suspense fallback={<LoadingFallback />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import MapLayout from './layouts/map'
 import api from './config/api'
 
 import { regionPath } from '@/lib/shape'
+import { initTheme } from '@/hooks/use-theme'
 import { ErrorFallback, LoadingFallback } from '@/components/atoms'
 import EventPage from '@/pages/event'
 import VenuePage from '@/pages/venue'
@@ -31,6 +32,11 @@ type AppProps = {
 }
 
 export default function App(props: AppProps) {
+  // Restore the persisted (or default) theme once on mount. Afterwards useTheme
+  // and ThemeSwitch keep the root class in sync; the Ladle decorator drives it
+  // there instead (stories don't render App).
+  useEffect(() => initTheme(), [])
+
   return (
     <Providers>
       <Suspense fallback={<LoadingFallback />}>

--- a/src/Widget.tsx
+++ b/src/Widget.tsx
@@ -4,6 +4,7 @@ import { HashRouter } from 'react-router'
 import App from './App'
 import i18n from './config/i18n'
 import atlasAuth from './config/api/auth'
+import { initTheme } from './hooks/use-theme'
 
 // Implementation of embeddable Widget
 // Demo in: demo.html
@@ -29,6 +30,9 @@ export default function Widget({ apiKey, locale }: WidgetProps) {
   if (!window.location.hash) {
     window.location.hash = HASH_BASE
   }
+
+  // Restore the persisted (or default) theme before first paint to avoid a flash.
+  initTheme()
 
   return (
     <HashRouter basename={HASH_BASE}>

--- a/src/components/atoms/Chip/Chip.stories.tsx
+++ b/src/components/atoms/Chip/Chip.stories.tsx
@@ -24,8 +24,7 @@ const colors = ['primary', 'secondary', 'default'] as const
 
 /**
  * Chip — a compact, uppercase label built on NextUI's Chip with app defaults.
- * Showcases the colour × emphasis matrix, the icon slot, and how chips read on a
- * dark surface.
+ * Showcases the colour × emphasis matrix and the icon slot.
  */
 export const Default: Story = () => (
   <StoryWrapper>
@@ -67,14 +66,6 @@ export const Default: Story = () => (
         <Chip color="secondary" icon={<OnlineCallIcon size={14} />}>
           online
         </Chip>
-      </div>
-    </StorySection>
-
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="flex flex-wrap items-center gap-2">
-        <Chip>online</Chip>
-        <Chip color="secondary">Français</Chip>
-        <Chip icon={<EventIcon size={14} />}>weekly</Chip>
       </div>
     </StorySection>
 

--- a/src/components/atoms/Dropdown/Dropdown.stories.tsx
+++ b/src/components/atoms/Dropdown/Dropdown.stories.tsx
@@ -4,7 +4,7 @@ import { StoryWrapper, StorySection } from '../../ladle'
 
 import { Dropdown, DropdownItem } from './Dropdown'
 
-import { LanguageIcon, LocationIcon, DownArrowIcon } from '@/components/atoms/Icons'
+import { LocationIcon, DownArrowIcon } from '@/components/atoms/Icons'
 
 export default {
   title: 'Atoms',
@@ -23,7 +23,7 @@ const triggerClass =
  * Dropdown — a portaled popover with viewport-aware placement (flip/shift) built
  * on Floating UI. `DropdownItem` renders an `<a>` for links (`href`) and a
  * `<button>` for actions (`onClick`). Panel chrome uses NextUI semantic tokens,
- * so it follows light/dark + the accent theme (see the dark surface below).
+ * so it follows light/dark + the accent theme.
  */
 export const Default: Story = () => (
   <StoryWrapper>
@@ -93,22 +93,6 @@ export const Default: Story = () => (
           </StorySection>
         ))}
       </div>
-    </StorySection>
-
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <Dropdown
-        trigger={
-          <span className={triggerClass}>
-            <LanguageIcon size={18} />
-            Language
-          </span>
-        }
-      >
-        <DropdownItem className="text-primary" onClick={() => {}}>
-          English
-        </DropdownItem>
-        <DropdownItem onClick={() => {}}>Français</DropdownItem>
-      </Dropdown>
     </StorySection>
 
     <StorySection inContext={true} title="Examples">

--- a/src/components/atoms/Fallbacks/Fallbacks.stories.tsx
+++ b/src/components/atoms/Fallbacks/Fallbacks.stories.tsx
@@ -30,12 +30,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="h-64 w-full">
-        <LoadingFallback />
-      </div>
-    </StorySection>
-
     <div />
   </StoryWrapper>
 )

--- a/src/components/atoms/Icons/Icons.stories.tsx
+++ b/src/components/atoms/Icons/Icons.stories.tsx
@@ -67,16 +67,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="flex flex-wrap items-center gap-6 text-white">
-        <SearchIcon size={28} />
-        <Logo size={28} />
-        <CalendarIcon size={28} />
-        <LocationIcon size={28} />
-        <EventIcon size={28} />
-      </div>
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="flex flex-col gap-3">
         <span className="flex items-center gap-2 text-default-700">

--- a/src/components/atoms/LanguageSelector/LanguageSelector.stories.tsx
+++ b/src/components/atoms/LanguageSelector/LanguageSelector.stories.tsx
@@ -22,10 +22,6 @@ export const Default: Story = () => (
       <LanguageSelector />
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <LanguageSelector />
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="flex items-center gap-4 text-default-700">
         <span className="text-sm">Language</span>

--- a/src/components/atoms/Panel/Panel.stories.tsx
+++ b/src/components/atoms/Panel/Panel.stories.tsx
@@ -48,12 +48,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <Panel>
-        <Placeholder label="Panel on a dark surface" />
-      </Panel>
-    </StorySection>
-
     <div />
   </StoryWrapper>
 )

--- a/src/components/atoms/ThemeSwitch/ThemeSwitch.stories.tsx
+++ b/src/components/atoms/ThemeSwitch/ThemeSwitch.stories.tsx
@@ -21,10 +21,6 @@ export const Default: Story = () => (
       <ThemeSwitch />
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <ThemeSwitch />
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="flex items-center gap-3 text-default-700">
         <span className="text-sm">Appearance</span>

--- a/src/components/ladle/StorySection.tsx
+++ b/src/components/ladle/StorySection.tsx
@@ -4,11 +4,14 @@ import type { ReactNode } from 'react'
  * Unified StorySection component for consistent story structure in Ladle.
  * Ported from WeMeditateWeb for parity — see STORYBOOK.md.
  *
+ * Chrome uses NextUI semantic tokens so it stays legible in both themes; the
+ * canvas theme is driven by Ladle's own toggle (see .ladle/components.tsx).
+ *
  * @param title - Section title (renders as h2 for sections, p for subsections)
  * @param description - Optional description text below the title
  * @param children - The section content
- * @param theme - Text color theme: 'light' (dark text) or 'dark' (white text)
- * @param background - Background style: 'none', 'neutral' (gray), or 'gradient' (teal)
+ * @param background - Context background simulating the map surface panels float
+ *   over: 'none', 'neutral' (semantic surface), or 'gradient' (brand teal)
  * @param variant - Section type: 'section', 'subsection', or 'scrollable'
  * @param inContext - When true, adds "In Context" prefix to title and bold top border
  */
@@ -16,7 +19,6 @@ export interface StorySectionProps {
   title: string
   description?: string
   children: ReactNode
-  theme?: 'light' | 'dark'
   background?: 'none' | 'neutral' | 'gradient'
   variant?: 'section' | 'subsection' | 'scrollable'
   inContext?: boolean
@@ -26,41 +28,22 @@ export const StorySection = ({
   title,
   description,
   children,
-  theme = 'light',
   background = 'none',
   variant = 'section',
   inContext = false,
 }: StorySectionProps) => {
-  // Background styles based on theme and background type
+  // Context backgrounds that simulate the map surface panels float over. The
+  // teal gradient is a fixed brand colour that reads on both themes; neutral
+  // uses a semantic surface token.
   const getBackgroundStyles = () => {
-    if (background === 'none') return ''
-
-    const baseStyles = 'p-6 rounded-lg'
-
-    if (background === 'neutral') {
-      return theme === 'dark' ? `bg-gray-800 ${baseStyles}` : `bg-gray-50 ${baseStyles}`
-    }
-
-    if (background === 'gradient') {
-      return theme === 'dark'
-        ? `bg-gradient-to-b from-teal-600 to-teal-700 ${baseStyles}`
-        : `bg-gradient-to-b from-teal-50 to-teal-100 ${baseStyles}`
-    }
+    if (background === 'neutral') return 'bg-default-100 p-6 rounded-lg'
+    if (background === 'gradient')
+      return 'bg-gradient-to-b from-teal-600 to-teal-700 p-6 rounded-lg'
 
     return ''
   }
 
-  // Text colors based on theme. For non-subsection sections, the title/description
-  // sit on the light wrapper background, so they always use light-theme colors.
-  const getTitleColor = () => {
-    if (variant === 'subsection') {
-      return theme === 'dark' ? 'text-gray-100' : 'text-gray-700'
-    }
-
-    return 'text-gray-900'
-  }
-
-  const descriptionColor = 'text-gray-600'
+  const titleColor = variant === 'subsection' ? 'text-default-600' : 'text-foreground'
 
   const variantConfig = {
     section: {
@@ -88,50 +71,38 @@ export const StorySection = ({
 
   const config = variantConfig[variant]
   const TitleTag = config.tag
-  const titleColor = getTitleColor()
   const backgroundStyles = getBackgroundStyles()
 
   const displayTitle =
     inContext && title ? `In Context - ${title}` : inContext ? 'In Context' : title
 
-  // `dark` class is added so NextUI/Tailwind components inside a dark section
-  // render in dark mode (the story canvas itself is always light — see
-  // .ladle/components.tsx). This is the one adaptation from WeMeditate's helper
-  // for our NextUI-themed stack.
-  const childrenTextColor = theme === 'dark' ? 'dark text-white' : ''
-
   const renderContent = () => {
     if (config.isScrollable) {
-      const borderColor = theme === 'dark' ? 'border-gray-700' : 'border-gray-200'
-      const scrollBackground =
-        backgroundStyles ||
-        (theme === 'dark' ? 'bg-gradient-to-b from-teal-600 to-teal-700' : 'bg-white')
+      const scrollBackground = backgroundStyles || 'bg-background'
 
       return (
-        <div className={`h-[600px] overflow-y-auto border-4 ${borderColor} -m-6`}>
-          <div className={`min-h-full px-6 ${scrollBackground} ${childrenTextColor}`}>
-            {children}
-          </div>
+        <div className="h-[600px] overflow-y-auto border-4 border-default-200 -m-6">
+          <div className={`min-h-full px-6 ${scrollBackground}`}>{children}</div>
         </div>
       )
     }
 
     if (backgroundStyles) {
-      return <div className={`${backgroundStyles} ${childrenTextColor}`}>{children}</div>
+      return <div className={backgroundStyles}>{children}</div>
     }
 
-    return <div className={childrenTextColor}>{children}</div>
+    return <>{children}</>
   }
 
   return (
     <>
       <div className={config.wrapperClass}>
-        {inContext && <div className="border-t-4 border-gray-900 mb-6 pt-8" />}
+        {inContext && <div className="border-t-4 border-foreground mb-6 pt-8" />}
         <TitleTag className={`${config.titleClass} ${titleColor}`}>{displayTitle}</TitleTag>
-        {description && <p className={`text-sm ${descriptionColor} mb-4`}>{description}</p>}
+        {description && <p className="text-sm text-default-500 mb-4">{description}</p>}
         {renderContent()}
       </div>
-      {config.showDivider && <hr className="border-gray-200" />}
+      {config.showDivider && <hr className="border-divider" />}
     </>
   )
 }

--- a/src/components/ladle/StorySection.tsx
+++ b/src/components/ladle/StorySection.tsx
@@ -33,12 +33,12 @@ export const StorySection = ({
   inContext = false,
 }: StorySectionProps) => {
   // Context backgrounds that simulate the map surface panels float over. The
-  // teal gradient is a fixed brand colour that reads on both themes; neutral
-  // uses a semantic surface token.
+  // teal gradient is a fixed dark brand colour, so its text is pinned white to
+  // read in both themes; neutral uses a theme-aware semantic surface token.
   const getBackgroundStyles = () => {
     if (background === 'neutral') return 'bg-default-100 p-6 rounded-lg'
     if (background === 'gradient')
-      return 'bg-gradient-to-b from-teal-600 to-teal-700 p-6 rounded-lg'
+      return 'bg-gradient-to-b from-teal-600 to-teal-700 p-6 rounded-lg text-white'
 
     return ''
   }

--- a/src/components/molecules/EventImages/EventImages.stories.tsx
+++ b/src/components/molecules/EventImages/EventImages.stories.tsx
@@ -33,12 +33,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="max-w-md">
-        <EventImages images={mockEventImages} />
-      </div>
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="max-w-md rounded-lg border border-divider overflow-hidden">
         <EventImages images={mockEventImages} />

--- a/src/components/molecules/EventItem/EventItem.stories.tsx
+++ b/src/components/molecules/EventItem/EventItem.stories.tsx
@@ -33,12 +33,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="max-w-md">
-        <EventItem event={mockEventSlim} />
-      </div>
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="max-w-md rounded-lg border border-divider overflow-hidden">
         <List>

--- a/src/components/molecules/EventShare/EventShare.stories.tsx
+++ b/src/components/molecules/EventShare/EventShare.stories.tsx
@@ -32,12 +32,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="max-w-sm">
-        <ShareContent label={mockEvent.title} url={mockEvent.webUrl ?? ''} />
-      </div>
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="flex max-w-md items-center justify-end gap-2 rounded-lg border border-divider p-4">
         <span className="text-sm text-default-600">{mockEvent.title}</span>

--- a/src/components/molecules/EventSoon/EventSoon.stories.tsx
+++ b/src/components/molecules/EventSoon/EventSoon.stories.tsx
@@ -41,10 +41,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <EventSoonChip firstDate={soonInPerson} online={false} />
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="flex max-w-md items-center gap-1">
         <EventSoonChip firstDate={soonInPerson} online={false} />

--- a/src/components/molecules/EventTime/EventTime.stories.tsx
+++ b/src/components/molecules/EventTime/EventTime.stories.tsx
@@ -45,12 +45,8 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <EventTime showTimeZone endTime="11:00" nextDate={nextDate} timeZone="Europe/London" />
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
-      <div className="max-w-md text-xs text-gray-500">
+      <div className="max-w-md text-xs text-default-500">
         <EventTime showTimeZone endTime="11:00" nextDate={nextDate} timeZone="Europe/London" />
       </div>
     </StorySection>

--- a/src/components/molecules/List/List.stories.tsx
+++ b/src/components/molecules/List/List.stories.tsx
@@ -45,16 +45,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="max-w-md">
-        <ListHeader backHref="#region" title="Cambridge" />
-        <List>
-          <ListItem count={12} href="#area" label="Cambridge" />
-          <ListItem count={7} href="#area" label="Oxford" />
-        </List>
-      </div>
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="max-w-md rounded-lg border border-divider overflow-hidden">
         <ListHeader backHref="#region" title="Cambridgeshire" />

--- a/src/components/molecules/ListItem/ListItem.stories.tsx
+++ b/src/components/molecules/ListItem/ListItem.stories.tsx
@@ -26,12 +26,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="max-w-md">
-        <ListItem count={3} href="#area" label="London" subtitle="Greater London" />
-      </div>
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="max-w-md rounded-lg border border-divider overflow-hidden">
         <List>

--- a/src/components/molecules/Navbar/Navbar.stories.tsx
+++ b/src/components/molecules/Navbar/Navbar.stories.tsx
@@ -22,12 +22,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="border border-divider rounded-lg overflow-hidden">
-        <Navbar isBordered />
-      </div>
-    </StorySection>
-
     <StorySection inContext={true} title="Examples">
       <div className="border border-divider rounded-lg overflow-hidden">
         <Navbar isBordered />

--- a/src/components/molecules/SearchBar/SearchBar.stories.tsx
+++ b/src/components/molecules/SearchBar/SearchBar.stories.tsx
@@ -61,10 +61,6 @@ export const Default: Story = () => (
         <SearchBar backHref="#search" header="Saturday Morning Meditation" />
       </StorySection>
 
-      <StorySection background="neutral" theme="dark" title="Dark Surface">
-        <SearchBar filterable eventCount={8} header="Cambridge" />
-      </StorySection>
-
       <StorySection inContext={true} title="Examples">
         <div className="max-w-md rounded-lg border border-divider overflow-hidden">
           <SearchBar

--- a/src/components/organisms/EventDetails/EventDetails.tsx
+++ b/src/components/organisms/EventDetails/EventDetails.tsx
@@ -131,7 +131,7 @@ function EventTimingDetails({
           : t('details.contact_for_timing')
       }
     >
-      <div className="text-tiny bg-primary-100 py-0.5 font-semibold">
+      <div className="text-tiny bg-primary-100 dark:bg-primary-900 py-0.5 font-semibold">
         {nextDate.toLocaleString({ month: 'short' }).toUpperCase()}
       </div>
       <div className="flex items-center justify-center font-semibold text-md h-6 text-default-500">

--- a/src/components/organisms/EventPanel/EventPanel.stories.tsx
+++ b/src/components/organisms/EventPanel/EventPanel.stories.tsx
@@ -13,7 +13,7 @@ export default { title: 'Organisms' } satisfies StoryDefault
 /**
  * EventPanel — the full event detail panel (header, images, description,
  * timing/location/contact cards, registration). Shown for an in-person event,
- * an online event, and an event with no images, plus on a dark surface.
+ * an online event, and an event with no images.
  */
 export const Default: Story = () => (
   <StoryWrapper>
@@ -32,12 +32,6 @@ export const Default: Story = () => (
     <StorySection description="An event without images." title="No Images">
       <div className="max-w-md border border-default-200">
         <EventPanel event={{ ...mockEvent, images: [] }} />
-      </div>
-    </StorySection>
-
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="max-w-md border border-default-200">
-        <EventPanel event={mockEvent} />
       </div>
     </StorySection>
 

--- a/src/components/organisms/EventsList/EventsList.stories.tsx
+++ b/src/components/organisms/EventsList/EventsList.stories.tsx
@@ -33,12 +33,6 @@ export const Default: Story = () => (
       </div>
     </StorySection>
 
-    <StorySection background="neutral" theme="dark" title="Dark Surface">
-      <div className="max-w-md">
-        <EventsList events={mockEventSlimList} />
-      </div>
-    </StorySection>
-
     <div />
   </StoryWrapper>
 )

--- a/src/components/organisms/Mapbox/layers.ts
+++ b/src/components/organisms/Mapbox/layers.ts
@@ -18,6 +18,8 @@ export const clusterLayer: Props = {
     'text-size': 12,
   },
   paint: {
+    // White count sits on the opaque `cluster` sprite (not the basemap), so it
+    // stays legible on both the light and dark map styles — no theming needed.
     'text-color': '#FFFFFF',
   },
 }
@@ -68,6 +70,8 @@ export const boundsLayer: LayerProps = {
     'line-cap': 'round',
   },
   paint: {
+    // Debug-only layer (rendered behind DEBUG_BOUNDARY in Map.tsx); the neutral
+    // mid-grey reads on both basemaps, so it needs no theme-aware variant.
     'line-color': '#888',
     'line-width': 4,
   },

--- a/src/hooks/use-theme.test.ts
+++ b/src/hooks/use-theme.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { applyTheme, initTheme } from './use-theme'
+
+// The unit lane is node-only (no jsdom — see .claude/rules/tests.md), so we stub
+// the minimal `<html>` classList surface and `localStorage` that the theme
+// helpers touch, then assert their DOM-light contracts directly.
+function stubDocument() {
+  const classes = new Set<string>()
+
+  vi.stubGlobal('document', {
+    documentElement: {
+      classList: {
+        add: (c: string) => classes.add(c),
+        remove: (...cs: string[]) => cs.forEach((c) => classes.delete(c)),
+        contains: (c: string) => classes.has(c),
+      },
+    },
+  })
+
+  return classes
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('applyTheme', () => {
+  it('adds the requested theme class and clears the other', () => {
+    const classes = stubDocument()
+
+    applyTheme('dark')
+    expect(classes.has('dark')).toBe(true)
+    expect(classes.has('light')).toBe(false)
+
+    applyTheme('light')
+    expect(classes.has('light')).toBe(true)
+    expect(classes.has('dark')).toBe(false)
+  })
+})
+
+describe('initTheme', () => {
+  it('is a no-op outside the browser (no document)', () => {
+    expect(() => initTheme()).not.toThrow()
+  })
+
+  it('restores the persisted theme', () => {
+    const classes = stubDocument()
+
+    vi.stubGlobal('localStorage', { getItem: () => 'dark', setItem: () => {} })
+
+    initTheme()
+    expect(classes.has('dark')).toBe(true)
+  })
+
+  it('falls back to the default theme when nothing is stored', () => {
+    const classes = stubDocument()
+
+    vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {} })
+
+    initTheme('dark')
+    expect(classes.has('dark')).toBe(true)
+  })
+
+  it('falls back to the default when localStorage throws (sandboxed iframe)', () => {
+    const classes = stubDocument()
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+      setItem: () => {
+        throw new Error('SecurityError')
+      },
+    })
+
+    expect(() => initTheme()).not.toThrow()
+    expect(classes.has('light')).toBe(true)
+  })
+})

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -38,25 +38,40 @@ export const applyTheme = (theme: Theme) => {
   root.classList.add(theme)
 }
 
+// localStorage can throw — not just be absent — in sandboxed iframes (a
+// `sandbox` without `allow-same-origin`) and some privacy modes, which matters
+// since this ships as an embeddable widget. Wrap reads/writes so the theme class
+// still updates; the choice just isn't persisted.
+const readStoredTheme = (): Theme | null => {
+  try {
+    return localStorage.getItem(ThemeProps.key) as Theme | null
+  } catch {
+    return null
+  }
+}
+
+const persistTheme = (theme: Theme) => {
+  try {
+    localStorage.setItem(ThemeProps.key, theme)
+  } catch {
+    // storage unavailable — ignore; the root class still reflects the choice
+  }
+}
+
 // Apply the persisted (or default) theme to the root class once at startup, so
 // the standalone app and widget restore the user's choice. Afterwards useTheme's
 // setters keep the class in sync. Guarded to be a no-op outside the browser.
 export const initTheme = (defaultTheme: Theme = ThemeProps.light) => {
   if (typeof document === 'undefined') return
 
-  const stored =
-    typeof localStorage === 'undefined'
-      ? null
-      : (localStorage.getItem(ThemeProps.key) as Theme | null)
-
-  applyTheme(stored ?? defaultTheme)
+  applyTheme(readStoredTheme() ?? defaultTheme)
 }
 
 export const useTheme = () => {
   const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 
   const setTheme = (next: Theme) => {
-    localStorage.setItem(ThemeProps.key, next)
+    persistTheme(next)
     applyTheme(next)
   }
 

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,6 +1,7 @@
-// originally written by @imoaazahmed
+// originally written by @imoaazahmed; reworked to observe the root class so a
+// single theme signal drives NextUI, Tailwind, and the Mapbox basemap.
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 
 const ThemeProps = {
   key: 'theme',
@@ -10,37 +11,68 @@ const ThemeProps = {
 
 type Theme = typeof ThemeProps.light | typeof ThemeProps.dark
 
-export const useTheme = (defaultTheme?: Theme) => {
-  const [theme, setTheme] = useState<Theme>(() => {
-    const storedTheme = localStorage.getItem(ThemeProps.key) as Theme | null
+// The root <html> class is the single source of truth: NextUI, Tailwind
+// (darkMode: 'class'), and the Mapbox basemap (MAP_STYLES[theme]) all key off
+// it. useTheme observes the class so every consumer reacts to a change made
+// anywhere — ThemeSwitch, the Ladle theme toggle, etc.
+const subscribe = (onChange: () => void) => {
+  const observer = new MutationObserver(onChange)
 
-    return storedTheme || (defaultTheme ?? ThemeProps.light)
-  })
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
 
-  const isDark = useMemo(() => {
-    return theme === ThemeProps.dark
-  }, [theme])
+  return () => observer.disconnect()
+}
 
-  const isLight = useMemo(() => {
-    return theme === ThemeProps.light
-  }, [theme])
+const getSnapshot = (): Theme =>
+  document.documentElement.classList.contains(ThemeProps.dark) ? ThemeProps.dark : ThemeProps.light
 
-  const _setTheme = (theme: Theme) => {
-    localStorage.setItem(ThemeProps.key, theme)
-    document.documentElement.classList.remove(ThemeProps.light, ThemeProps.dark)
-    document.documentElement.classList.add(theme)
-    setTheme(theme)
+// Stories and unit tests render via renderToStaticMarkup (no DOM); default light.
+const getServerSnapshot = (): Theme => ThemeProps.light
+
+const applyTheme = (theme: Theme) => {
+  const root = document.documentElement
+
+  root.classList.remove(ThemeProps.light, ThemeProps.dark)
+  root.classList.add(theme)
+}
+
+// Apply the persisted (or default) theme to the root class once at startup, so
+// the standalone app and widget restore the user's choice. Afterwards useTheme's
+// setters keep the class in sync. Guarded to be a no-op outside the browser.
+export const initTheme = (defaultTheme: Theme = ThemeProps.light) => {
+  if (typeof document === 'undefined') return
+
+  const stored =
+    typeof localStorage === 'undefined'
+      ? null
+      : (localStorage.getItem(ThemeProps.key) as Theme | null)
+
+  applyTheme(stored ?? defaultTheme)
+}
+
+export const useTheme = () => {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  const setTheme = useCallback((next: Theme) => {
+    localStorage.setItem(ThemeProps.key, next)
+    applyTheme(next)
+  }, [])
+
+  const setLightTheme = useCallback(() => setTheme(ThemeProps.light), [setTheme])
+  const setDarkTheme = useCallback(() => setTheme(ThemeProps.dark), [setTheme])
+  // Read the live class rather than closing over `theme`, so the callback stays
+  // stable and never toggles from a stale value.
+  const toggleTheme = useCallback(
+    () => setTheme(getSnapshot() === ThemeProps.dark ? ThemeProps.light : ThemeProps.dark),
+    [setTheme],
+  )
+
+  return {
+    theme,
+    isDark: theme === ThemeProps.dark,
+    isLight: theme === ThemeProps.light,
+    setLightTheme,
+    setDarkTheme,
+    toggleTheme,
   }
-
-  const setLightTheme = () => _setTheme(ThemeProps.light)
-
-  const setDarkTheme = () => _setTheme(ThemeProps.dark)
-
-  const toggleTheme = () => (theme === ThemeProps.dark ? setLightTheme() : setDarkTheme())
-
-  useEffect(() => {
-    _setTheme(theme)
-  })
-
-  return { theme, isDark, isLight, setLightTheme, setDarkTheme, toggleTheme }
 }

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,7 +1,7 @@
 // originally written by @imoaazahmed; reworked to observe the root class so a
 // single theme signal drives NextUI, Tailwind, and the Mapbox basemap.
 
-import { useCallback, useSyncExternalStore } from 'react'
+import { useSyncExternalStore } from 'react'
 
 const ThemeProps = {
   key: 'theme',
@@ -29,7 +29,9 @@ const getSnapshot = (): Theme =>
 // Stories and unit tests render via renderToStaticMarkup (no DOM); default light.
 const getServerSnapshot = (): Theme => ThemeProps.light
 
-const applyTheme = (theme: Theme) => {
+// The single seam for writing the theme to the root class — used by useTheme's
+// setters, initTheme, and the Ladle decorator so the mechanism never drifts.
+export const applyTheme = (theme: Theme) => {
   const root = document.documentElement
 
   root.classList.remove(ThemeProps.light, ThemeProps.dark)
@@ -53,26 +55,20 @@ export const initTheme = (defaultTheme: Theme = ThemeProps.light) => {
 export const useTheme = () => {
   const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 
-  const setTheme = useCallback((next: Theme) => {
+  const setTheme = (next: Theme) => {
     localStorage.setItem(ThemeProps.key, next)
     applyTheme(next)
-  }, [])
-
-  const setLightTheme = useCallback(() => setTheme(ThemeProps.light), [setTheme])
-  const setDarkTheme = useCallback(() => setTheme(ThemeProps.dark), [setTheme])
-  // Read the live class rather than closing over `theme`, so the callback stays
-  // stable and never toggles from a stale value.
-  const toggleTheme = useCallback(
-    () => setTheme(getSnapshot() === ThemeProps.dark ? ThemeProps.light : ThemeProps.dark),
-    [setTheme],
-  )
+  }
 
   return {
     theme,
     isDark: theme === ThemeProps.dark,
     isLight: theme === ThemeProps.light,
-    setLightTheme,
-    setDarkTheme,
-    toggleTheme,
+    setLightTheme: () => setTheme(ThemeProps.light),
+    setDarkTheme: () => setTheme(ThemeProps.dark),
+    // Read the live class rather than closing over `theme`, so the toggle never
+    // acts on a stale value.
+    toggleTheme: () =>
+      setTheme(getSnapshot() === ThemeProps.dark ? ThemeProps.light : ThemeProps.dark),
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,16 @@ import { BrowserRouter } from 'react-router'
 
 import App from './App.tsx'
 import atlasAuth from './config/api/auth'
+import { initTheme } from './hooks/use-theme'
 
 if (!atlasAuth.apiKey) {
   const searchParams = new URLSearchParams(window.location.search)
 
   atlasAuth.apiKey = searchParams.get('key') || import.meta.env.VITE_SAHAJCLOUD_API_KEY
 }
+
+// Restore the persisted (or default) theme before first paint to avoid a flash.
+initTheme()
 
 ReactDOM.createRoot(document.getElementById('syatlas')!).render(
   <BrowserRouter>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -263,27 +263,24 @@ module.exports = {
           },
         },
         dark: {
-          extend: {
-            colors: {
-              primary: {
-                ...ORANGE_COLOR,
-                foreground: '#FFFFFF',
-              },
-              secondary: {
-                ...TEAL_COLOR,
-                foreground: '#000000',
-              },
-              danger: {
-                ...ORANGE_COLOR,
-                foreground: '#000000',
-              },
+          // NextUI's `extend` takes a base-theme *name* (string); nesting colors
+          // under it silently drops them, so the custom dark palette never
+          // applied. Mirror the light theme: put colors at the theme level so
+          // they merge onto NextUI's built-in dark base.
+          colors: {
+            primary: {
+              ...ORANGE_COLOR,
+              foreground: '#FFFFFF',
             },
-            borderColor: {
-              DEFAULT: '#1e1e1e',
+            secondary: {
+              ...TEAL_COLOR,
+              foreground: '#000000',
             },
-            backgroundColor: {
-              DEFAULT: '#1e1e1e',
+            danger: {
+              ...ORANGE_COLOR,
+              foreground: '#000000',
             },
+            focus: ORANGE_COLOR,
           },
         },
       },


### PR DESCRIPTION
## Summary

Unifies dark mode so a single signal — the root `<html>` class — drives NextUI, Tailwind, **and** the Mapbox basemap, and lets Ladle's own theme toggle re-theme the entire story canvas.

- `useTheme` now observes the root class (via `useSyncExternalStore` + `MutationObserver`) instead of giving each component its own `useState` plus a per-render class write. A theme change made anywhere (ThemeSwitch, the Ladle toggle) propagates to every consumer — including the map basemap, which previously could not follow an externally-set theme.
- Ladle's light/dark/auto toggle drives the whole preview canvas; the per-story `<StorySection theme="dark">` "Dark Surface" blocks (18 stories) are removed along with the `theme` prop on `StorySection`, whose chrome is now expressed in NextUI semantic tokens so it reads in both themes.

## Changes

- `src/hooks/use-theme.ts` — reactive, root-class-derived theme; exports `applyTheme()` (the single class-writing seam) and `initTheme()` (startup restore). No more dependency-less per-render class write.
- `src/main.tsx`, `src/Widget.tsx` — call `initTheme()` before first paint (no flash); `App.tsx` no longer inits.
- `.ladle/components.tsx` — decorator maps `useLadleContext().globalState.theme` onto the root class through `applyTheme()` (resolves `auto` via `matchMedia`, tracked live); canvas defers its background to Ladle's own theme.
- `src/components/ladle/StorySection.tsx` — drops the `theme` prop and all `theme === 'dark'` branches; semantic-token chrome; theme-aware `neutral`/`gradient` backgrounds retained.
- 18 `*.stories.tsx` — removed "Dark Surface" sections; reworded 3 docstrings; one `text-gray-500` → `text-default-500`.
- `src/components/organisms/Mapbox/layers.ts` — comments documenting why the white cluster count and debug-only `#888` bounds line need no theming.
- `tailwind.config.js` — fix the dark theme so the custom brand palette (orange/teal) actually applies in dark; `EventDetails` month-label gets a dark brand surface in dark mode so its text stays legible.

## Verification

- Lint: ✓ (`pnpm lint`)
- Types: ✓ (`pnpm typecheck`)
- Unit: ✓ 79 passed / 19 files (`pnpm test:run`)
- Build: ✓ (`pnpm build`)
- Ladle build: ✓ (`pnpm ladle:build`)

## Manual / visual verification

Drove the running Ladle (Playwright MCP), toggling the theme on representative stories in **both** light and dark:

1. **EventPanel / EventDetails** — with the brand palette now applied in dark, the "JUL" date strip (`dark:bg-primary-900`), borders, highlighted contact icon, chips, and the "Register" button all read in both themes.
2. **Map** — basemap flips bidirectionally with the toggle (light style ↔ dark style); this was the previously-broken behavior.
3. **EventsList** — items, chips, distances, and `dark:hover:bg-default-100` hover all legible in dark.
4. **Chip** — palette matrix (primary = orange, secondary = teal) and `StorySection` chrome (titles, grid headers, dividers, `inContext` rule) legible in both themes.

## Notes for reviewer

- **Fixed the dark-palette config bug.** `tailwind.config.js` nested the dark theme's `colors` under NextUI's `extend` (which takes a base-theme *name* string, not an object), so the custom dark palette never applied and dark mode used NextUI's default blue/purple. Moved colors to the theme level (mirroring the light theme); dark now renders the brand orange/teal.
- **That exposed the one real change-#5 component fix:** our `*-100` shades are fixed light tints, so once the palette applied, the EventDetails month-label `bg-primary-100` strip would have rendered light-on-light in dark — given a dark brand surface there (`dark:bg-primary-900`). EventItem/ListItem hover, `border-primary-100`, the highlighted contact icon, and the Mapbox layers were all re-verified legible in dark with the brand palette and need no change.
- Per reviewer feedback, the Ladle canvas no longer forces `bg-background`; it defers to Ladle's own theme background.
- A `/code-review` (max effort, with verification) and a 4-angle `/simplify` pass were run over the branch — **no correctness bugs**. From the `/review` pass, `localStorage` access in `useTheme` is now wrapped so the toggle survives sandboxed-iframe embeds / blocked storage (with a co-located test).

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
