### PR TITLE
feat(ui): white-label brand palette for the embedded widget

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -19,7 +19,7 @@ import '@/styles/globals.css'
 const PALETTES: Record<string, PaletteRoles> = {
   'palette: wemeditate.com': {},
   'palette: shrimataji.org': { primary: '#64032E', secondary: '#A11F0C', background: '#F0ECE2' },
-  'palette: sahajayoga.org': { primary: '#62834B', secondary: '#5D6F44' },
+  'palette: sahajayoga.org': { primary: '#5D6F44', secondary: '#D47B2C' },
 }
 
 // Global decorator for every story.

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -68,14 +68,13 @@ export const Provider: GlobalProvider = ({ children }) => {
   const { theme } = useTheme()
 
   // Re-paint the wrapper when the chosen palette or the resolved theme changes.
-  // Clear prior inline vars first so switching back to Default restores the
-  // built-in palette (applyPalette no-ops omitted roles, it doesn't unset them).
+  // applyPalette resets the managed vars before applying, so switching back to
+  // Default restores the built-in palette on its own.
   useEffect(() => {
     const el = wrapperRef.current
 
     if (!el) return
 
-    el.removeAttribute('style')
     applyPalette(el, PALETTES[palette], theme)
   }, [palette, theme])
 

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -1,6 +1,6 @@
 import type { GlobalProvider } from '@ladle/react'
 
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ThemeState, useLadleContext } from '@ladle/react'
 import { MemoryRouter } from 'react-router'
 import { I18nextProvider } from 'react-i18next'
@@ -8,9 +8,19 @@ import { I18nextProvider } from 'react-i18next'
 import storyI18n from './i18n'
 
 import Providers from '@/providers'
-import { applyTheme } from '@/hooks/use-theme'
+import { applyTheme, useTheme } from '@/hooks/use-theme'
+import { applyPalette, type PaletteRoles } from '@/config/theme/palette'
 
 import '@/styles/globals.css'
+
+// Brand presets sampled from real tenants (issue #16). Selecting one runs the
+// production applyPalette on the story wrapper, so Ladle previews exactly what
+// an embed renders. "Default" applies no override (built-in teal/orange).
+const PALETTES: Record<string, PaletteRoles> = {
+  'Default (teal)': {},
+  'Shrimataji (maroon)': { primary: '#64032E', secondary: '#7A404E', background: '#F0ECE2' },
+  'Sahajayoga (green)': { primary: '#468503', secondary: '#4C6539' },
+}
 
 // Global decorator for every story.
 //
@@ -31,6 +41,10 @@ import '@/styles/globals.css'
 // Mapbox basemap (which follows useTheme). `auto` resolves against the OS
 // preference and tracks it live. The canvas background is left to Ladle's own
 // theme so it matches the surrounding chrome.
+//
+// Brand palette: a fixed switcher applies a tenant preset to the story wrapper
+// via the production applyPalette, re-applying when the palette or the resolved
+// light/dark theme changes.
 export const Provider: GlobalProvider = ({ children }) => {
   const { globalState } = useLadleContext()
   const ladleTheme = globalState.theme
@@ -49,11 +63,41 @@ export const Provider: GlobalProvider = ({ children }) => {
     applyTheme(ladleTheme === ThemeState.Dark ? 'dark' : 'light')
   }, [ladleTheme])
 
+  const [palette, setPalette] = useState('Default (teal)')
+  const wrapperRef = useRef<HTMLElement>(null)
+  const { theme } = useTheme()
+
+  // Re-paint the wrapper when the chosen palette or the resolved theme changes.
+  // Clear prior inline vars first so switching back to Default restores the
+  // built-in palette (applyPalette no-ops omitted roles, it doesn't unset them).
+  useEffect(() => {
+    const el = wrapperRef.current
+
+    if (!el) return
+
+    el.removeAttribute('style')
+    applyPalette(el, PALETTES[palette], theme)
+  }, [palette, theme])
+
   return (
     <I18nextProvider i18n={storyI18n}>
       <MemoryRouter>
         <Providers>
-          <main className="min-h-screen p-6 text-foreground">{children}</main>
+          <main ref={wrapperRef} className="min-h-screen p-6 text-foreground">
+            <select
+              aria-label="Brand palette"
+              style={{ position: 'fixed', top: 8, right: 8, zIndex: 50 }}
+              value={palette}
+              onChange={(event) => setPalette(event.target.value)}
+            >
+              {Object.keys(PALETTES).map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+            {children}
+          </main>
         </Providers>
       </MemoryRouter>
     </I18nextProvider>

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -17,9 +17,9 @@ import '@/styles/globals.css'
 // production applyPalette on the story wrapper, so Ladle previews exactly what
 // an embed renders. "Default" applies no override (built-in teal/orange).
 const PALETTES: Record<string, PaletteRoles> = {
-  'wemeditate.com': {},
-  'shrimataji.org': { primary: '#64032E', secondary: '#AF94A3', background: '#F0ECE2' },
-  'sahajayoga.org': { primary: '#62834B', secondary: '#5D6F44' },
+  'palette: wemeditate.com': {},
+  'palette: shrimataji.org': { primary: '#64032E', secondary: '#A11F0C', background: '#F0ECE2' },
+  'palette: sahajayoga.org': { primary: '#62834B', secondary: '#5D6F44' },
 }
 
 // Global decorator for every story.
@@ -63,7 +63,7 @@ export const Provider: GlobalProvider = ({ children }) => {
     applyTheme(ladleTheme === ThemeState.Dark ? 'dark' : 'light')
   }, [ladleTheme])
 
-  const [palette, setPalette] = useState('wemeditate.com')
+  const [palette, setPalette] = useState('palette: wemeditate.com')
   const wrapperRef = useRef<HTMLElement>(null)
   const { theme } = useTheme()
 

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -17,9 +17,9 @@ import '@/styles/globals.css'
 // production applyPalette on the story wrapper, so Ladle previews exactly what
 // an embed renders. "Default" applies no override (built-in teal/orange).
 const PALETTES: Record<string, PaletteRoles> = {
-  'Default (teal)': {},
-  'Shrimataji (maroon)': { primary: '#64032E', secondary: '#7A404E', background: '#F0ECE2' },
-  'Sahajayoga (green)': { primary: '#468503', secondary: '#4C6539' },
+  'wemeditate.com': {},
+  'shrimataji.org': { primary: '#64032E', secondary: '#AF94A3', background: '#F0ECE2' },
+  'sahajayoga.org': { primary: '#62834B', secondary: '#5D6F44' },
 }
 
 // Global decorator for every story.
@@ -63,7 +63,7 @@ export const Provider: GlobalProvider = ({ children }) => {
     applyTheme(ladleTheme === ThemeState.Dark ? 'dark' : 'light')
   }, [ladleTheme])
 
-  const [palette, setPalette] = useState('Default (teal)')
+  const [palette, setPalette] = useState('wemeditate.com')
   const wrapperRef = useRef<HTMLElement>(null)
   const { theme } = useTheme()
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/luxon": "^3.4.2",
     "axios": "^1.7.9",
     "clsx": "2.1.1",
+    "colord": "^2.9.3",
     "dompurify": "^3.2.3",
     "fathom-client": "^3.7.2",
     "framer-motion": "^11.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      colord:
+        specifier: ^2.9.3
+        version: 2.9.3
       dompurify:
         specifier: ^3.2.3
         version: 3.2.3
@@ -2401,6 +2404,9 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -7956,6 +7962,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
+
+  colord@2.9.3: {}
 
   combined-stream@1.0.8:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Route, Routes, useLocation } from 'react-router'
 import { Helmet } from 'react-helmet-async'
-import { Suspense, useEffect } from 'react'
+import { Suspense, useEffect, type RefObject } from 'react'
 import * as Fathom from 'fathom-client'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -10,6 +10,7 @@ import { useLocale } from './hooks/use-locale'
 import Providers from './providers'
 import MapLayout from './layouts/map'
 import api from './config/api'
+import { BrandTheme } from './config/theme/BrandTheme'
 
 import { regionPath } from '@/lib/shape'
 import { ErrorFallback, LoadingFallback } from '@/components/atoms'
@@ -23,21 +24,28 @@ import '@/styles/globals.css'
 import '@/config/i18n'
 import i18n from '@/config/i18n'
 
+import type { PaletteRoles } from '@/config/theme/palette'
+
 // ===== APP ===== //
 
 type AppProps = {
   apiKey: string | undefined | null
   defaultLocale?: string | null
+  // Per-embed brand palette + the wrapper to scope theming to (widget only).
+  brand?: PaletteRoles
+  themeRootRef?: RefObject<HTMLElement | null>
 }
 
-export default function App(props: AppProps) {
+export default function App({ apiKey, defaultLocale, brand, themeRootRef }: AppProps) {
   return (
     <Providers>
-      <Suspense fallback={<LoadingFallback />}>
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
-          <AppRouter {...props} />
-        </ErrorBoundary>
-      </Suspense>
+      <BrandTheme apiKey={apiKey} palette={brand} rootRef={themeRootRef}>
+        <Suspense fallback={<LoadingFallback />}>
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <AppRouter apiKey={apiKey} defaultLocale={defaultLocale} />
+          </ErrorBoundary>
+        </Suspense>
+      </BrandTheme>
     </Providers>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { useNavigationState } from './config/store'
 import { useLocale } from './hooks/use-locale'
 import Providers from './providers'
 import MapLayout from './layouts/map'
-import api from './config/api'
+import { clientQuery } from './config/api'
 import { BrandTheme } from './config/theme/BrandTheme'
 
 import { regionPath } from '@/lib/shape'
@@ -31,7 +31,9 @@ import i18n from '@/config/i18n'
 type AppProps = {
   apiKey: string | undefined | null
   defaultLocale?: string | null
-  // Per-embed brand palette + the wrapper to scope theming to (widget only).
+  // Per-embed brand palette. Theming itself is app-wide (standalone also paints
+  // the client's colors onto <html>); only `themeRootRef` — the widget wrapper
+  // to scope the vars + theme class to — is widget-specific.
   brand?: PaletteRoles
   themeRootRef?: RefObject<HTMLElement | null>
 }
@@ -57,10 +59,7 @@ function AppRouter({ apiKey, defaultLocale }: AppProps) {
     throw new Error('Missing api key.')
   }
 
-  const { data: client } = useSuspenseQuery({
-    queryKey: ['client', apiKey],
-    queryFn: () => api.getClient(),
-  })
+  const { data: client } = useSuspenseQuery(clientQuery(apiKey))
 
   // The widget's home view is its configured region; fall back to the search index.
   const initialPath =

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import type { PaletteRoles } from '@/config/theme/palette'
+
 import { Navigate, Route, Routes, useLocation } from 'react-router'
 import { Helmet } from 'react-helmet-async'
 import { Suspense, useEffect, type RefObject } from 'react'
@@ -23,8 +25,6 @@ import IndexPage from '@/pages/index'
 import '@/styles/globals.css'
 import '@/config/i18n'
 import i18n from '@/config/i18n'
-
-import type { PaletteRoles } from '@/config/theme/palette'
 
 // ===== APP ===== //
 

--- a/src/Widget.tsx
+++ b/src/Widget.tsx
@@ -1,10 +1,11 @@
 import r2wc from '@r2wc/react-to-web-component'
 import { HashRouter } from 'react-router'
+import { useRef } from 'react'
 
 import App from './App'
 import i18n from './config/i18n'
 import atlasAuth from './config/api/auth'
-import { initTheme } from './hooks/use-theme'
+import { getInitialTheme } from './hooks/use-theme'
 
 // Implementation of embeddable Widget
 // Demo in: demo.html
@@ -16,9 +17,20 @@ type WidgetProps = {
   apiKey: string
   locale?: string
   basePath?: string
+  // Per-embed brand palette (hex). Each role overrides the client record's
+  // color; omitted roles fall back to the record, then the built-in default.
+  primaryColor?: string
+  secondaryColor?: string
+  backgroundColor?: string
 }
 
-export default function Widget({ apiKey, locale }: WidgetProps) {
+export default function Widget({
+  apiKey,
+  locale,
+  primaryColor,
+  secondaryColor,
+  backgroundColor,
+}: WidgetProps) {
   if (!atlasAuth.apiKey) {
     atlasAuth.apiKey = apiKey
   }
@@ -31,12 +43,24 @@ export default function Widget({ apiKey, locale }: WidgetProps) {
     window.location.hash = HASH_BASE
   }
 
-  // Restore the persisted (or default) theme before first paint to avoid a flash.
-  initTheme()
+  // The widget scopes its theme to this wrapper so it never mutates the host
+  // page's <html>. Set the initial light/dark class synchronously to avoid a
+  // flash; BrandTheme adopts the wrapper as the theme root + paints the brand
+  // palette once mounted.
+  const themeRootRef = useRef<HTMLDivElement>(null)
 
   return (
     <HashRouter basename={HASH_BASE}>
-      <App apiKey={apiKey} defaultLocale={locale} />
+      {/* display:contents keeps the wrapper out of the layout while still
+          carrying the theme class + brand CSS vars down to every descendant. */}
+      <div ref={themeRootRef} className={getInitialTheme()} style={{ display: 'contents' }}>
+        <App
+          apiKey={apiKey}
+          brand={{ primary: primaryColor, secondary: secondaryColor, background: backgroundColor }}
+          defaultLocale={locale}
+          themeRootRef={themeRootRef}
+        />
+      </div>
     </HashRouter>
   )
 }
@@ -47,6 +71,9 @@ customElements.define(
     props: {
       apiKey: 'string',
       locale: 'string',
+      primaryColor: 'string',
+      secondaryColor: 'string',
+      backgroundColor: 'string',
     },
   }),
 )

--- a/src/config/api/index.ts
+++ b/src/config/api/index.ts
@@ -1,7 +1,17 @@
 import fetch from './fetch'
 import mutate from './mutate'
 
-export default {
+const api = {
   ...fetch,
   ...mutate,
 }
+
+// The client-record query contract in one place — shared by AppRouter's
+// suspense read and BrandTheme's non-suspense read so the key + fetcher can't
+// drift between them.
+export const clientQuery = (apiKey?: string | null) => ({
+  queryKey: ['client', apiKey] as const,
+  queryFn: () => api.getClient(),
+})
+
+export default api

--- a/src/config/theme/BrandTheme.tsx
+++ b/src/config/theme/BrandTheme.tsx
@@ -1,0 +1,63 @@
+import { useLayoutEffect, useMemo, type ReactNode, type RefObject } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import api from '@/config/api'
+import { applyPalette, type PaletteRoles } from '@/config/theme/palette'
+import { setThemeRoot, useTheme } from '@/hooks/use-theme'
+
+type BrandThemeProps = {
+  // The widget's own service record supplies the fallback palette; its key is
+  // also BrandTheme's query key, so it shares AppRouter's `['client']` fetch.
+  apiKey?: string | null
+  // Per-embed palette from the widget's color props; wins over the client record.
+  palette?: PaletteRoles
+  // The widget wrapper to scope theming to; absent standalone (root stays <html>).
+  rootRef?: RefObject<HTMLElement | null>
+  children: ReactNode
+}
+
+// Resolves the active brand palette (per-embed prop ?? client record ?? built-in
+// default, per role) and paints it onto the theme root as NextUI CSS vars.
+//
+// It renders *above* the Suspense boundary so the prop palette themes the
+// loading fallback immediately; the client record (color1/2/3 → primary /
+// secondary / background) merges in once its query resolves. Re-applies the
+// mode-aware DEFAULT/foreground whenever the theme flips light↔dark.
+export function BrandTheme({ apiKey, palette, rootRef, children }: BrandThemeProps) {
+  const { theme } = useTheme()
+
+  const { data: client } = useQuery({
+    queryKey: ['client', apiKey],
+    queryFn: () => api.getClient(),
+    enabled: !!apiKey,
+  })
+
+  const resolved = useMemo<PaletteRoles>(
+    () => ({
+      primary: palette?.primary ?? client?.color1,
+      secondary: palette?.secondary ?? client?.color2,
+      background: palette?.background ?? client?.color3,
+    }),
+    [
+      palette?.primary,
+      palette?.secondary,
+      palette?.background,
+      client?.color1,
+      client?.color2,
+      client?.color3,
+    ],
+  )
+
+  // useLayoutEffect runs before the browser paints, so the palette (and the
+  // wrapper as the theme root) are in place for the first frame — no flash.
+  // `theme` in the deps re-applies the mode-aware DEFAULT/foreground on a flip.
+  useLayoutEffect(() => {
+    if (typeof document === 'undefined') return
+
+    if (rootRef?.current) setThemeRoot(rootRef.current)
+
+    applyPalette(rootRef?.current ?? document.documentElement, resolved, theme)
+  }, [resolved, theme, rootRef])
+
+  return <>{children}</>
+}

--- a/src/config/theme/BrandTheme.tsx
+++ b/src/config/theme/BrandTheme.tsx
@@ -49,15 +49,25 @@ export function BrandTheme({ apiKey, palette, rootRef, children }: BrandThemePro
 
   // useLayoutEffect runs before the browser paints, so the palette (and the
   // wrapper as the theme root) are in place for the first frame — no flash.
-  // `theme` in the deps re-applies the mode-aware DEFAULT/foreground on a flip.
   useLayoutEffect(() => {
     if (typeof document === 'undefined') return
 
     // Adopt the widget wrapper as the theme root (null → stays <html>), then
-    // paint the resolved palette onto whichever element that resolves to.
+    // paint the resolved palette onto it. Mode is read from the root's own class
+    // rather than `theme`: on the widget's first paint the `theme` snapshot can
+    // still reflect <html> (before setThemeRoot adopts the wrapper), which would
+    // paint a dark wrapper in light tones. `theme` stays in the deps to re-run
+    // this on a light↔dark toggle.
     setThemeRoot(rootRef?.current ?? null)
-    applyPalette(getThemeRoot(), resolved, theme)
+    const root = getThemeRoot()
+
+    applyPalette(root, resolved, root.classList.contains('dark') ? 'dark' : 'light')
   }, [resolved, theme, rootRef])
+
+  // Release the theme root when this widget unmounts so a torn-down embed stops
+  // owning the module-level root (and its detached wrapper can be GC'd). Assumes
+  // one widget per page; a second concurrent embed would share this singleton.
+  useLayoutEffect(() => () => setThemeRoot(null), [])
 
   return <>{children}</>
 }

--- a/src/config/theme/BrandTheme.tsx
+++ b/src/config/theme/BrandTheme.tsx
@@ -1,9 +1,9 @@
 import { useLayoutEffect, useMemo, type ReactNode, type RefObject } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
-import api from '@/config/api'
+import { clientQuery } from '@/config/api'
 import { applyPalette, type PaletteRoles } from '@/config/theme/palette'
-import { setThemeRoot, useTheme } from '@/hooks/use-theme'
+import { getThemeRoot, setThemeRoot, useTheme } from '@/hooks/use-theme'
 
 type BrandThemeProps = {
   // The widget's own service record supplies the fallback palette; its key is
@@ -27,8 +27,7 @@ export function BrandTheme({ apiKey, palette, rootRef, children }: BrandThemePro
   const { theme } = useTheme()
 
   const { data: client } = useQuery({
-    queryKey: ['client', apiKey],
-    queryFn: () => api.getClient(),
+    ...clientQuery(apiKey),
     enabled: !!apiKey,
   })
 
@@ -54,9 +53,10 @@ export function BrandTheme({ apiKey, palette, rootRef, children }: BrandThemePro
   useLayoutEffect(() => {
     if (typeof document === 'undefined') return
 
-    if (rootRef?.current) setThemeRoot(rootRef.current)
-
-    applyPalette(rootRef?.current ?? document.documentElement, resolved, theme)
+    // Adopt the widget wrapper as the theme root (null → stays <html>), then
+    // paint the resolved palette onto whichever element that resolves to.
+    setThemeRoot(rootRef?.current ?? null)
+    applyPalette(getThemeRoot(), resolved, theme)
   }, [resolved, theme, rootRef])
 
   return <>{children}</>

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -148,4 +148,19 @@ describe('applyPalette', () => {
 
     expect(props.size).toBe(0)
   })
+
+  it('clears a role that is dropped on a later apply (reverts to the default)', () => {
+    const { root, props } = fakeRoot()
+
+    applyPalette(root, { primary: '#64032e', secondary: '#7a404e', background: '#f0ece2' }, 'light')
+    expect(props.has('--nextui-secondary')).toBe(true)
+    expect(props.has('--nextui-background')).toBe(true)
+
+    // Re-apply with only primary → secondary + background revert to the default.
+    applyPalette(root, { primary: '#64032e' }, 'light')
+    expect(props.has('--nextui-secondary')).toBe(false)
+    expect(props.has('--nextui-secondary-100')).toBe(false)
+    expect(props.has('--nextui-background')).toBe(false)
+    expect(props.get('--nextui-primary')).toBe('333 94% 20%')
+  })
 })

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -3,23 +3,6 @@ import { colord } from 'colord'
 
 import { buildScale, applyPalette, type ColorScale } from './palette'
 
-// The hand-tuned default ramp from tailwind.config.js — buildScale should
-// reproduce it from its seed (#82b1ae) within rounding/drift tolerance.
-const TEAL = {
-  DEFAULT: '#82b1ae',
-  10: '#f4f8f7',
-  50: '#c1d8d7',
-  100: '#b1cfcc',
-  200: '#a2c5c2',
-  300: '#92bbb8',
-  400: '#82b1ae',
-  500: '#73a7a4',
-  600: '#639e99',
-  700: '#598f8a',
-  800: '#4f7f7b',
-  900: '#456f6c',
-}
-
 const SHADES = [10, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const
 
 const parse = (s: string) => {
@@ -40,55 +23,32 @@ describe('buildScale', () => {
     }
   })
 
-  it('approximates the hand-tuned TEAL ramp from its seed', () => {
-    const scale = buildScale('#82b1ae')
-
-    for (const shade of SHADES) {
-      const generated = parse(scale[shade])
-      const original = colord(TEAL[shade]).toHsl()
-
-      // Lightness is lifted directly from the teal ramp → near-exact.
-      expect(Math.abs(generated.l - original.l)).toBeLessThanOrEqual(1)
-      // Hue is preserved from the seed; the near-white `10` step loses hue
-      // precision, so only assert it where the color actually carries hue.
-      if (original.l < 90) expect(Math.abs(generated.h - original.h)).toBeLessThanOrEqual(6)
-    }
-  })
-
-  it('uses a muted seed verbatim as the DEFAULT', () => {
-    const scale = buildScale('#82b1ae') // teal sits below the saturation cap
-    const seed = colord('#82b1ae').toHsl()
+  it('uses only the input hue — fixed saturation, ignoring input saturation/lightness', () => {
+    // #468503 is a vivid (≈96% sat), dark (≈27% L) green; the scale keeps only
+    // its hue and pins saturation + lightness to the fixed ladders.
+    const scale = buildScale('#468503')
     const def = parse(scale.DEFAULT)
 
-    expect(def).toEqual({ h: seed.h, s: seed.s, l: seed.l })
+    expect(def.h).toBe(89) // hue preserved
+    expect(def.s).toBe(60) // fixed saturation, not the seed's 96
+    expect(def.l).toBe(60) // fixed solid lightness, not the seed's 27
+
+    for (const shade of SHADES) expect(parse(scale[shade]).s).toBe(60)
   })
 
-  it('caps the saturation of a vivid seed, leaving muted seeds untouched', () => {
-    // Neon green (#468503 ≈ 96% sat) is pulled down to the cap so it matches the
-    // muted register of the rest of the UI; hue + lightness are preserved.
-    const green = parse(buildScale('#468503').DEFAULT)
-
-    expect(green.s).toBe(60)
-    expect(green.h).toBe(89)
-
-    // The default teal (≈23% sat) is already below the cap → unchanged.
-    expect(parse(buildScale('#82b1ae').DEFAULT).s).toBe(23)
+  it('produces the identical scale for two seeds that share a hue', () => {
+    // Bright red and dark maroon are the same hue (0°) at very different
+    // saturation/lightness → identical generated scale.
+    expect(buildScale('#ff0000')).toEqual(buildScale('#800000'))
   })
 })
 
 describe('foreground contrast', () => {
-  it('picks black on a light seed and white on a dark seed', () => {
-    expect(buildScale('#ffffff').foreground).toBe('0 0% 0%')
-    expect(buildScale('#82b1ae').foreground).toBe('0 0% 0%') // teal → black (matches today)
-    expect(buildScale('#000000').foreground).toBe('0 0% 100%')
-    expect(buildScale('#64032e').foreground).toBe('0 0% 100%') // dark maroon → white
-  })
-
-  it('flips black → white as the seed darkens past the contrast boundary', () => {
-    // A mid-grey ramp crosses the boundary; the light half reads black, the
-    // dark half reads white.
-    expect(buildScale('#999999').foreground).toBe('0 0% 0%')
-    expect(buildScale('#555555').foreground).toBe('0 0% 100%')
+  it('picks a readable on-color for the fixed-lightness solid, by hue', () => {
+    // The solid sits at a fixed lightness, so the on-color depends on the hue:
+    // a luminous hue reads black, a low-luminance hue reads white.
+    expect(buildScale('#468503').foreground).toBe('0 0% 0%') // green → black
+    expect(buildScale(colord({ h: 240, s: 60, l: 40 }).toHex()).foreground).toBe('0 0% 100%') // blue → white
   })
 })
 
@@ -112,15 +72,15 @@ describe('applyPalette', () => {
 
     applyPalette(root, { primary: '#64032e' }, 'light')
 
-    expect(props.get('--nextui-primary')).toBe('333 60% 20%')
-    expect(props.get('--nextui-primary-foreground')).toBe('0 0% 100%')
+    expect(props.get('--nextui-primary')).toBe('333 60% 60%')
+    expect(props.get('--nextui-primary-foreground')).toBe('0 0% 0%')
     expect(props.get('--nextui-primary-100')).toBeDefined()
     expect(props.get('--nextui-primary-900')).toBeDefined()
     // Focus follows primary.
-    expect(props.get('--nextui-focus')).toBe('333 60% 20%')
+    expect(props.get('--nextui-focus')).toBe('333 60% 60%')
   })
 
-  it('lightens + desaturates the DEFAULT in dark mode (no vanishing primary)', () => {
+  it('uses a lighter solid tone in dark mode (no vanishing primary)', () => {
     const { root, props } = fakeRoot()
 
     applyPalette(root, { primary: '#64032e' }, 'dark')
@@ -128,8 +88,8 @@ describe('applyPalette', () => {
     const def = parse(props.get('--nextui-primary')!)
 
     expect(def.h).toBe(333) // hue preserved
-    expect(def.l).toBeGreaterThanOrEqual(60) // raised tone
-    expect(def.s).toBeLessThan(94) // slightly desaturated
+    expect(def.s).toBe(60) // fixed saturation
+    expect(def.l).toBe(70) // lighter than the light-mode 60
   })
 
   it('leaves omitted roles untouched', () => {
@@ -173,6 +133,6 @@ describe('applyPalette', () => {
     expect(props.has('--nextui-secondary')).toBe(false)
     expect(props.has('--nextui-secondary-100')).toBe(false)
     expect(props.has('--nextui-background')).toBe(false)
-    expect(props.get('--nextui-primary')).toBe('333 60% 20%')
+    expect(props.get('--nextui-primary')).toBe('333 60% 60%')
   })
 })

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -41,6 +41,12 @@ describe('buildScale', () => {
     // saturation/lightness → identical generated scale.
     expect(buildScale('#ff0000')).toEqual(buildScale('#800000'))
   })
+
+  it('keeps a near-neutral seed neutral (no invented hue)', () => {
+    // Charcoal is achromatic (colord reports hue 0); it must NOT become a
+    // saturated red — its low saturation passes through instead of the fixed 60.
+    expect(parse(buildScale('#333333').DEFAULT).s).toBeLessThan(10)
+  })
 })
 
 describe('foreground contrast', () => {

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest'
-import { colord } from 'colord'
 
 import { buildScale, applyPalette, type ColorScale } from './palette'
 
@@ -23,38 +22,29 @@ describe('buildScale', () => {
     }
   })
 
-  it('uses only the input hue — fixed saturation, ignoring input saturation/lightness', () => {
-    // #468503 is a vivid (≈96% sat), dark (≈27% L) green; the scale keeps only
-    // its hue and pins saturation + lightness to the fixed ladders.
-    const scale = buildScale('#468503')
-    const def = parse(scale.DEFAULT)
+  it('respects the seed hue + lightness and caps saturation', () => {
+    // Dark maroon stays dark; its ≈94% saturation is capped to the muted register.
+    const maroon = parse(buildScale('#64032e').DEFAULT)
 
-    expect(def.h).toBe(89) // hue preserved
-    expect(def.s).toBe(60) // fixed saturation, not the seed's 96
-    expect(def.l).toBe(60) // fixed solid lightness, not the seed's 27
+    expect(maroon.h).toBe(333)
+    expect(maroon.l).toBe(20) // the seed's own lightness, preserved
+    expect(maroon.s).toBe(60) // capped from 94
 
-    for (const shade of SHADES) expect(parse(scale[shade]).s).toBe(60)
+    // A muted seed keeps its low saturation (not pushed up to the cap).
+    expect(parse(buildScale('#82b1ae').DEFAULT).s).toBe(23)
   })
 
-  it('produces the identical scale for two seeds that share a hue', () => {
-    // Bright red and dark maroon are the same hue (0°) at very different
-    // saturation/lightness → identical generated scale.
-    expect(buildScale('#ff0000')).toEqual(buildScale('#800000'))
-  })
-
-  it('keeps a near-neutral seed neutral (no invented hue)', () => {
-    // Charcoal is achromatic (colord reports hue 0); it must NOT become a
-    // saturated red — its low saturation passes through instead of the fixed 60.
+  it('keeps a near-neutral seed neutral (the cap leaves low saturation alone)', () => {
+    // Charcoal is achromatic; min(s, cap) preserves its ~0 saturation, so it never
+    // becomes a vivid color from colord's hue=0 convention.
     expect(parse(buildScale('#333333').DEFAULT).s).toBeLessThan(10)
   })
 })
 
 describe('foreground contrast', () => {
-  it('picks a readable on-color for the fixed-lightness solid, by hue', () => {
-    // The solid sits at a fixed lightness, so the on-color depends on the hue:
-    // a luminous hue reads black, a low-luminance hue reads white.
-    expect(buildScale('#468503').foreground).toBe('0 0% 0%') // green → black
-    expect(buildScale(colord({ h: 240, s: 60, l: 40 }).toHex()).foreground).toBe('0 0% 100%') // blue → white
+  it('picks a readable on-color for the brand solid (by its lightness)', () => {
+    expect(buildScale('#82b1ae').foreground).toBe('0 0% 0%') // light teal → black
+    expect(buildScale('#64032e').foreground).toBe('0 0% 100%') // dark maroon → white
   })
 })
 
@@ -78,15 +68,15 @@ describe('applyPalette', () => {
 
     applyPalette(root, { primary: '#64032e' }, 'light')
 
-    expect(props.get('--nextui-primary')).toBe('333 60% 60%')
-    expect(props.get('--nextui-primary-foreground')).toBe('0 0% 0%')
+    expect(props.get('--nextui-primary')).toBe('333 60% 20%')
+    expect(props.get('--nextui-primary-foreground')).toBe('0 0% 100%')
     expect(props.get('--nextui-primary-100')).toBeDefined()
     expect(props.get('--nextui-primary-900')).toBeDefined()
     // Focus follows primary.
-    expect(props.get('--nextui-focus')).toBe('333 60% 60%')
+    expect(props.get('--nextui-focus')).toBe('333 60% 20%')
   })
 
-  it('uses a lighter solid tone in dark mode (no vanishing primary)', () => {
+  it('lifts a dark solid to a visible tone in dark mode (no vanishing primary)', () => {
     const { root, props } = fakeRoot()
 
     applyPalette(root, { primary: '#64032e' }, 'dark')
@@ -94,8 +84,8 @@ describe('applyPalette', () => {
     const def = parse(props.get('--nextui-primary')!)
 
     expect(def.h).toBe(333) // hue preserved
-    expect(def.s).toBe(60) // fixed saturation
-    expect(def.l).toBe(70) // lighter than the light-mode 60
+    expect(def.s).toBe(60) // capped saturation
+    expect(def.l).toBe(60) // lifted from the seed's dark 20 to the dark minimum
   })
 
   it('leaves omitted roles untouched', () => {
@@ -139,6 +129,6 @@ describe('applyPalette', () => {
     expect(props.has('--nextui-secondary')).toBe(false)
     expect(props.has('--nextui-secondary-100')).toBe(false)
     expect(props.has('--nextui-background')).toBe(false)
-    expect(props.get('--nextui-primary')).toBe('333 60% 60%')
+    expect(props.get('--nextui-primary')).toBe('333 60% 20%')
   })
 })

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -39,6 +39,12 @@ describe('buildScale', () => {
     // becomes a vivid color from colord's hue=0 convention.
     expect(parse(buildScale('#333333').DEFAULT).s).toBeLessThan(10)
   })
+
+  it('caps a near-white solid so it stays visible on the light canvas', () => {
+    // A near-white seed (#fafafa, L98) would be invisible as bg-primary; the solid
+    // lightness is capped, mirroring the dark-mode floor.
+    expect(parse(buildScale('#fafafa').DEFAULT).l).toBeLessThanOrEqual(70)
+  })
 })
 
 describe('foreground contrast', () => {

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -55,12 +55,24 @@ describe('buildScale', () => {
     }
   })
 
-  it('uses the seed verbatim as the DEFAULT', () => {
-    const scale = buildScale('#82b1ae')
+  it('uses a muted seed verbatim as the DEFAULT', () => {
+    const scale = buildScale('#82b1ae') // teal sits below the saturation cap
     const seed = colord('#82b1ae').toHsl()
     const def = parse(scale.DEFAULT)
 
     expect(def).toEqual({ h: seed.h, s: seed.s, l: seed.l })
+  })
+
+  it('caps the saturation of a vivid seed, leaving muted seeds untouched', () => {
+    // Neon green (#468503 ≈ 96% sat) is pulled down to the cap so it matches the
+    // muted register of the rest of the UI; hue + lightness are preserved.
+    const green = parse(buildScale('#468503').DEFAULT)
+
+    expect(green.s).toBe(60)
+    expect(green.h).toBe(89)
+
+    // The default teal (≈23% sat) is already below the cap → unchanged.
+    expect(parse(buildScale('#82b1ae').DEFAULT).s).toBe(23)
   })
 })
 
@@ -100,12 +112,12 @@ describe('applyPalette', () => {
 
     applyPalette(root, { primary: '#64032e' }, 'light')
 
-    expect(props.get('--nextui-primary')).toBe('333 94% 20%')
+    expect(props.get('--nextui-primary')).toBe('333 60% 20%')
     expect(props.get('--nextui-primary-foreground')).toBe('0 0% 100%')
     expect(props.get('--nextui-primary-100')).toBeDefined()
     expect(props.get('--nextui-primary-900')).toBeDefined()
     // Focus follows primary.
-    expect(props.get('--nextui-focus')).toBe('333 94% 20%')
+    expect(props.get('--nextui-focus')).toBe('333 60% 20%')
   })
 
   it('lightens + desaturates the DEFAULT in dark mode (no vanishing primary)', () => {
@@ -161,6 +173,6 @@ describe('applyPalette', () => {
     expect(props.has('--nextui-secondary')).toBe(false)
     expect(props.has('--nextui-secondary-100')).toBe(false)
     expect(props.has('--nextui-background')).toBe(false)
-    expect(props.get('--nextui-primary')).toBe('333 94% 20%')
+    expect(props.get('--nextui-primary')).toBe('333 60% 20%')
   })
 })

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { colord } from 'colord'
+
+import { buildScale, applyPalette, type ColorScale } from './palette'
+
+// The hand-tuned default ramp from tailwind.config.js — buildScale should
+// reproduce it from its seed (#82b1ae) within rounding/drift tolerance.
+const TEAL = {
+  DEFAULT: '#82b1ae',
+  10: '#f4f8f7',
+  50: '#c1d8d7',
+  100: '#b1cfcc',
+  200: '#a2c5c2',
+  300: '#92bbb8',
+  400: '#82b1ae',
+  500: '#73a7a4',
+  600: '#639e99',
+  700: '#598f8a',
+  800: '#4f7f7b',
+  900: '#456f6c',
+}
+
+const SHADES = [10, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const
+
+const parse = (s: string) => {
+  const [h, sPct, lPct] = s.split(' ')
+
+  return { h: Number(h), s: Number(sPct.replace('%', '')), l: Number(lPct.replace('%', '')) }
+}
+
+const lightnessOf = (scale: ColorScale, shade: (typeof SHADES)[number]) => parse(scale[shade]).l
+
+describe('buildScale', () => {
+  it('produces a monotonically darkening lightness ramp (10 → 900)', () => {
+    const scale = buildScale('#82b1ae')
+    const lightnesses = SHADES.map((shade) => lightnessOf(scale, shade))
+
+    for (let i = 1; i < lightnesses.length; i++) {
+      expect(lightnesses[i]).toBeLessThan(lightnesses[i - 1])
+    }
+  })
+
+  it('approximates the hand-tuned TEAL ramp from its seed', () => {
+    const scale = buildScale('#82b1ae')
+
+    for (const shade of SHADES) {
+      const generated = parse(scale[shade])
+      const original = colord(TEAL[shade]).toHsl()
+
+      // Lightness is lifted directly from the teal ramp → near-exact.
+      expect(Math.abs(generated.l - original.l)).toBeLessThanOrEqual(1)
+      // Hue is preserved from the seed; the near-white `10` step loses hue
+      // precision, so only assert it where the color actually carries hue.
+      if (original.l < 90) expect(Math.abs(generated.h - original.h)).toBeLessThanOrEqual(6)
+    }
+  })
+
+  it('uses the seed verbatim as the DEFAULT', () => {
+    const scale = buildScale('#82b1ae')
+    const seed = colord('#82b1ae').toHsl()
+    const def = parse(scale.DEFAULT)
+
+    expect(def).toEqual({ h: seed.h, s: seed.s, l: seed.l })
+  })
+})
+
+describe('foreground contrast', () => {
+  it('picks black on a light seed and white on a dark seed', () => {
+    expect(buildScale('#ffffff').foreground).toBe('0 0% 0%')
+    expect(buildScale('#82b1ae').foreground).toBe('0 0% 0%') // teal → black (matches today)
+    expect(buildScale('#000000').foreground).toBe('0 0% 100%')
+    expect(buildScale('#64032e').foreground).toBe('0 0% 100%') // dark maroon → white
+  })
+
+  it('flips black → white as the seed darkens past the contrast boundary', () => {
+    // A mid-grey ramp crosses the boundary; the light half reads black, the
+    // dark half reads white.
+    expect(buildScale('#999999').foreground).toBe('0 0% 0%')
+    expect(buildScale('#555555').foreground).toBe('0 0% 100%')
+  })
+})
+
+// A DOM-light stand-in for the root element so the var writes can be asserted
+// in the node-only lane (no jsdom — see .claude/rules/tests.md).
+function fakeRoot() {
+  const props = new Map<string, string>()
+  const root = {
+    style: {
+      setProperty: (k: string, v: string) => void props.set(k, v),
+      removeProperty: (k: string) => void props.delete(k),
+    },
+  } as unknown as HTMLElement
+
+  return { root, props }
+}
+
+describe('applyPalette', () => {
+  it('writes the primary scale, DEFAULT, foreground and focus vars', () => {
+    const { root, props } = fakeRoot()
+
+    applyPalette(root, { primary: '#64032e' }, 'light')
+
+    expect(props.get('--nextui-primary')).toBe('333 94% 20%')
+    expect(props.get('--nextui-primary-foreground')).toBe('0 0% 100%')
+    expect(props.get('--nextui-primary-100')).toBeDefined()
+    expect(props.get('--nextui-primary-900')).toBeDefined()
+    // Focus follows primary.
+    expect(props.get('--nextui-focus')).toBe('333 94% 20%')
+  })
+
+  it('lightens + desaturates the DEFAULT in dark mode (no vanishing primary)', () => {
+    const { root, props } = fakeRoot()
+
+    applyPalette(root, { primary: '#64032e' }, 'dark')
+
+    const def = parse(props.get('--nextui-primary')!)
+
+    expect(def.h).toBe(333) // hue preserved
+    expect(def.l).toBeGreaterThanOrEqual(60) // raised tone
+    expect(def.s).toBeLessThan(94) // slightly desaturated
+  })
+
+  it('leaves omitted roles untouched', () => {
+    const { root, props } = fakeRoot()
+
+    applyPalette(root, { primary: '#64032e' }, 'light')
+
+    expect([...props.keys()].some((k) => k.startsWith('--nextui-secondary'))).toBe(false)
+    expect(props.has('--nextui-background')).toBe(false)
+  })
+
+  it('applies the background override in light mode only', () => {
+    const light = fakeRoot()
+
+    applyPalette(light.root, { background: '#f0ece2' }, 'light')
+    expect(light.props.get('--nextui-background')).toBe('43 32% 91%')
+
+    const dark = fakeRoot()
+
+    applyPalette(dark.root, { background: '#f0ece2' }, 'dark')
+    expect(dark.props.has('--nextui-background')).toBe(false)
+  })
+
+  it('ignores invalid seed hexes', () => {
+    const { root, props } = fakeRoot()
+
+    applyPalette(root, { primary: 'not-a-color' }, 'light')
+
+    expect(props.size).toBe(0)
+  })
+})

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -45,11 +45,9 @@ export type ColorScale = {
   900: string
 }
 
-// Per-step lightness (HSL L%) lifted from the hand-tuned TEAL_COLOR ramp in
-// tailwind.config.js. We keep the seed's hue + saturation and only walk this
-// lightness ladder, so a generated scale carries the same visual weight at each
-// step as today's default (a near-linear 5%/step ramp, with `10` a light tint).
-// Verified by palette.test.ts against the original teal hexes.
+// Per-step lightness (HSL L%) — the hand-tuned default ramp's near-linear ladder
+// (≈5%/step from 50→900, with `10` a light tint). Generated scales walk this at
+// a fixed saturation and the input hue (see SCALE_SATURATION).
 const SCALE_LIGHTNESS: Record<keyof Omit<ColorScale, 'DEFAULT' | 'foreground'>, number> = {
   10: 96,
   50: 80,
@@ -81,46 +79,41 @@ const WHITE = '0 0% 100%'
 const foregroundFor = (c: Colord) =>
   c.contrast('#000000') >= c.contrast('#ffffff') ? BLACK : WHITE
 
-// The brand palette is deliberately muted (the default teal sits near 23%
-// saturation, orange near 63%). A very saturated seed — e.g. a vivid green —
-// would generate neon shades that read as harsh/glowing next to the rest of the
-// UI and unreadable as tinted text, so cap saturation to keep generated scales
-// in the same calm register. Low-saturation seeds pass through untouched.
-const MAX_SATURATION = 60
+// Generated scales take ONLY the input hue. Saturation is fixed and lightness
+// follows SCALE_LIGHTNESS, so every brand hue yields the same consistent,
+// readable range — in the spirit of Radix's color scales — regardless of how
+// saturated or light the seed was: a neon seed and a muted one at the same hue
+// produce the identical scale. (The built-in ramps work the same way — a
+// constant saturation over a lightness ladder: teal ≈ 23%, orange ≈ 62%.)
+const SCALE_SATURATION = 60
 
-const muted = (c: Colord): Colord => {
-  const { h, s, l } = c.toHsl()
+// The solid brand color (DEFAULT). In light mode it sits at the 400 step,
+// matching the built-in teal/orange whose DEFAULT is their own 400; in dark mode
+// it shifts to a lighter step so it stays visible on the dark canvas.
+const DEFAULT_LIGHTNESS = SCALE_LIGHTNESS[400]
+const DARK_DEFAULT_LIGHTNESS = SCALE_LIGHTNESS[200]
 
-  return s <= MAX_SATURATION ? c : colord({ h, s: MAX_SATURATION, l })
-}
+const darkTone = (h: number): Colord =>
+  colord({ h, s: SCALE_SATURATION, l: DARK_DEFAULT_LIGHTNESS })
 
-// Dark-mode tone shift (Material 3 tonal guidance: preserve hue, raise tone,
-// desaturate slightly) so a dark brand color stays visible on the dark canvas
-// instead of vanishing into it. Lightness is clamped into a mid-high band (any
-// seed lands somewhere visible); saturation is eased back slightly.
-const darkTone = (c: Colord): Colord => {
-  const { h, s, l } = c.toHsl()
-
-  return colord({ h, s: s * 0.9, l: Math.min(Math.max(l, 60), 82) })
-}
-
-// Derive a NextUI color scale from a seed hex: the seed *is* the DEFAULT (so a
-// tenant's chosen brand color is used as-is in light mode), the 10…900 steps
-// follow SCALE_LIGHTNESS at the seed's hue/saturation, and `foreground` is the
-// readable on-color for the DEFAULT. Mode-aware DEFAULT/foreground for dark mode
-// are computed in applyPalette; this scale is the light-mode/canonical form.
+// Derive a NextUI color scale from a seed hex using ONLY its hue: the 10…900
+// steps walk SCALE_LIGHTNESS at the fixed SCALE_SATURATION, the DEFAULT is the
+// 400-step solid, and `foreground` is its readable on-color. Mode-aware
+// DEFAULT/foreground for dark mode are computed in applyPalette; this scale is
+// the light-mode/canonical form.
 export function buildScale(seedHex: string): ColorScale {
-  const seed = muted(colord(seedHex))
-  const { h, s } = seed.toHsl()
+  const { h } = colord(seedHex).toHsl()
 
   const steps = Object.fromEntries(
-    Object.entries(SCALE_LIGHTNESS).map(([shade, l]) => [shade, channel(h, s, l)]),
+    Object.entries(SCALE_LIGHTNESS).map(([shade, l]) => [shade, channel(h, SCALE_SATURATION, l)]),
   ) as Omit<ColorScale, 'DEFAULT' | 'foreground'>
+
+  const solid = colord({ h, s: SCALE_SATURATION, l: DEFAULT_LIGHTNESS })
 
   return {
     ...steps,
-    DEFAULT: toChannel(seed),
-    foreground: foregroundFor(seed),
+    DEFAULT: toChannel(solid),
+    foreground: foregroundFor(solid),
   }
 }
 
@@ -136,10 +129,9 @@ const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeM
     root.style.setProperty(`--nextui-${token}-${shade}`, value)
   }
 
-  // DEFAULT + foreground are the most visible (bg-primary / text-primary). Light
-  // mode uses the scale's seed-based values as-is; dark lightens the tone so a
-  // dark brand color stays visible on the dark canvas.
-  const tone = mode === 'dark' ? darkTone(muted(seed)) : null
+  // DEFAULT + foreground are the most visible (bg-primary / text-primary). Dark
+  // mode shifts the solid to a lighter tone so it stays visible on the dark canvas.
+  const tone = mode === 'dark' ? darkTone(seed.toHsl().h) : null
   const base = tone ? toChannel(tone) : scale.DEFAULT
   const foreground = tone ? foregroundFor(tone) : scale.foreground
 

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -83,7 +83,8 @@ const foregroundFor = (c: Colord) =>
 
 // Dark-mode tone shift (Material 3 tonal guidance: preserve hue, raise tone,
 // desaturate slightly) so a dark brand color stays visible on the dark canvas
-// instead of vanishing into it. Light brand colors are nudged up only if needed.
+// instead of vanishing into it. Lightness is clamped into a mid-high band (any
+// seed lands somewhere visible); saturation is eased back slightly.
 const darkTone = (c: Colord): Colord => {
   const { h, s, l } = c.toHsl()
 
@@ -117,21 +118,22 @@ const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeM
 
   const scale = buildScale(seedHex)
 
-  for (const shade of Object.keys(SCALE_LIGHTNESS)) {
-    root.style.setProperty(
-      `--nextui-${token}-${shade}`,
-      scale[shade as unknown as keyof ColorScale],
-    )
+  for (const [shade, value] of Object.entries(scale)) {
+    if (shade === 'DEFAULT' || shade === 'foreground') continue
+    root.style.setProperty(`--nextui-${token}-${shade}`, value)
   }
 
-  // DEFAULT + foreground are the most visible (bg-primary / text-primary). In
-  // light mode use the seed verbatim; in dark mode use the lightened tone.
-  const base = mode === 'dark' ? darkTone(seed) : seed
+  // DEFAULT + foreground are the most visible (bg-primary / text-primary). Light
+  // mode uses the scale's seed-based values as-is; dark lightens the tone so a
+  // dark brand color stays visible on the dark canvas.
+  const tone = mode === 'dark' ? darkTone(seed) : null
+  const base = tone ? toChannel(tone) : scale.DEFAULT
+  const foreground = tone ? foregroundFor(tone) : scale.foreground
 
-  root.style.setProperty(`--nextui-${token}`, toChannel(base))
-  root.style.setProperty(`--nextui-${token}-foreground`, foregroundFor(base))
+  root.style.setProperty(`--nextui-${token}`, base)
+  root.style.setProperty(`--nextui-${token}-foreground`, foreground)
 
-  return toChannel(base)
+  return base
 }
 
 // Repaint a root element in the supplied palette by writing NextUI's CSS vars
@@ -149,9 +151,11 @@ export function applyPalette(root: HTMLElement, palette: PaletteRoles, mode: The
 
   // The background override applies to light mode only; dark keeps its dark
   // neutral, so we clear any previously-set value when flipping to dark.
-  if (palette.background && colord(palette.background).isValid()) {
+  const background = palette.background ? colord(palette.background) : null
+
+  if (background?.isValid()) {
     if (mode === 'light') {
-      root.style.setProperty('--nextui-background', toChannel(colord(palette.background)))
+      root.style.setProperty('--nextui-background', toChannel(background))
     } else {
       root.style.removeProperty('--nextui-background')
     }

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -1,0 +1,159 @@
+// Runtime brand theming for the embedded widget.
+//
+// NextUI emits every semantic color as an HSL-*channel* CSS variable —
+// `--nextui-primary`, `--nextui-primary-{10,50…900}`, `--nextui-primary-foreground`
+// — and consumes them as `hsl(var(--nextui-primary) / <alpha>)` (see
+// @nextui-org/theme's resolver, which writes the value as `"<h> <s>% <l>%"`).
+// Because they're plain custom properties, we can repaint the whole widget at
+// runtime by setting those vars inline on a wrapper element: inline values beat
+// the `.light`/`.dark` class-defined ones and cascade to every NextUI component.
+//
+// A tenant supplies one seed hex per role; `buildScale` derives the full ramp
+// from it, and `applyPalette` writes the vars (mode-aware) onto the root. When
+// no palette is supplied nothing here runs and the static tailwind.config theme
+// stands unchanged.
+
+import { colord, extend, type Colord } from 'colord'
+import a11yPlugin from 'colord/plugins/a11y'
+
+// `.contrast()` (used to pick a black/white foreground by WCAG ratio).
+extend([a11yPlugin])
+
+export type ThemeMode = 'light' | 'dark'
+
+// One seed hex per themeable role; any role may be omitted (then it's left to
+// the built-in default). `background` themes the page surface in light mode only.
+export type PaletteRoles = {
+  primary?: string | null
+  secondary?: string | null
+  background?: string | null
+}
+
+export type ColorScale = {
+  DEFAULT: string
+  foreground: string
+  10: string
+  50: string
+  100: string
+  200: string
+  300: string
+  400: string
+  500: string
+  600: string
+  700: string
+  800: string
+  900: string
+}
+
+// Per-step lightness (HSL L%) lifted from the hand-tuned TEAL_COLOR ramp in
+// tailwind.config.js. We keep the seed's hue + saturation and only walk this
+// lightness ladder, so a generated scale carries the same visual weight at each
+// step as today's default (a near-linear 5%/step ramp, with `10` a light tint).
+// Verified by palette.test.ts against the original teal hexes.
+const SCALE_LIGHTNESS: Record<keyof Omit<ColorScale, 'DEFAULT' | 'foreground'>, number> = {
+  10: 96,
+  50: 80,
+  100: 75,
+  200: 70,
+  300: 65,
+  400: 60,
+  500: 55,
+  600: 50,
+  700: 45,
+  800: 40,
+  900: 35,
+}
+
+// NextUI's channel format: space-separated `<h> <s>% <l>%`, no `hsl()` wrapper.
+const channel = (h: number, s: number, l: number) =>
+  `${Math.round(h)} ${Math.round(s)}% ${Math.round(l)}%`
+
+const toChannel = (c: Colord) => {
+  const { h, s, l } = c.toHsl()
+
+  return channel(h, s, l)
+}
+
+const BLACK = '0 0% 0%'
+const WHITE = '0 0% 100%'
+
+// Black or white, whichever reads better on the given color (WCAG contrast).
+const foregroundFor = (c: Colord) =>
+  c.contrast('#000000') >= c.contrast('#ffffff') ? BLACK : WHITE
+
+// Dark-mode tone shift (Material 3 tonal guidance: preserve hue, raise tone,
+// desaturate slightly) so a dark brand color stays visible on the dark canvas
+// instead of vanishing into it. Light brand colors are nudged up only if needed.
+const darkTone = (c: Colord): Colord => {
+  const { h, s, l } = c.toHsl()
+
+  return colord({ h, s: s * 0.9, l: Math.min(Math.max(l, 60), 82) })
+}
+
+// Derive a NextUI color scale from a seed hex: the seed *is* the DEFAULT (so a
+// tenant's chosen brand color is used as-is in light mode), the 10…900 steps
+// follow SCALE_LIGHTNESS at the seed's hue/saturation, and `foreground` is the
+// readable on-color for the DEFAULT. Mode-aware DEFAULT/foreground for dark mode
+// are computed in applyPalette; this scale is the light-mode/canonical form.
+export function buildScale(seedHex: string): ColorScale {
+  const seed = colord(seedHex)
+  const { h, s } = seed.toHsl()
+
+  const steps = Object.fromEntries(
+    Object.entries(SCALE_LIGHTNESS).map(([shade, l]) => [shade, channel(h, s, l)]),
+  ) as Omit<ColorScale, 'DEFAULT' | 'foreground'>
+
+  return {
+    ...steps,
+    DEFAULT: toChannel(seed),
+    foreground: foregroundFor(seed),
+  }
+}
+
+const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeMode) => {
+  const seed = colord(seedHex)
+
+  if (!seed.isValid()) return
+
+  const scale = buildScale(seedHex)
+
+  for (const shade of Object.keys(SCALE_LIGHTNESS)) {
+    root.style.setProperty(
+      `--nextui-${token}-${shade}`,
+      scale[shade as unknown as keyof ColorScale],
+    )
+  }
+
+  // DEFAULT + foreground are the most visible (bg-primary / text-primary). In
+  // light mode use the seed verbatim; in dark mode use the lightened tone.
+  const base = mode === 'dark' ? darkTone(seed) : seed
+
+  root.style.setProperty(`--nextui-${token}`, toChannel(base))
+  root.style.setProperty(`--nextui-${token}-foreground`, foregroundFor(base))
+
+  return toChannel(base)
+}
+
+// Repaint a root element in the supplied palette by writing NextUI's CSS vars
+// inline. Omitted roles are left untouched (built-in default stands). `mode`
+// drives the DEFAULT/foreground tone and gates the background override.
+export function applyPalette(root: HTMLElement, palette: PaletteRoles, mode: ThemeMode) {
+  if (palette.primary) {
+    const primaryDefault = setRole(root, 'primary', palette.primary, mode)
+
+    // The focus ring follows the primary brand color.
+    if (primaryDefault) root.style.setProperty('--nextui-focus', primaryDefault)
+  }
+
+  if (palette.secondary) setRole(root, 'secondary', palette.secondary, mode)
+
+  // The background override applies to light mode only; dark keeps its dark
+  // neutral, so we clear any previously-set value when flipping to dark.
+  if (palette.background && colord(palette.background).isValid()) {
+    if (mode === 'light') {
+      root.style.setProperty('--nextui-background', toChannel(colord(palette.background)))
+    } else {
+      root.style.removeProperty('--nextui-background')
+    }
+  }
+}

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -87,8 +87,11 @@ const foregroundFor = (c: Colord) =>
 // is the brand color itself (capped), lifted to a visible tone in dark mode.
 const MAX_SATURATION = 60
 
-// In dark mode the solid is lifted to at least this lightness so a dark brand
-// color stays visible on the dark canvas.
+// Keep the solid visible against the canvas at either extreme: light mode caps
+// the lightness (a near-white brand wouldn't show on the light page), dark mode
+// floors it (a near-black brand wouldn't show on the dark page). A normal
+// mid-toned brand sits between these and is used as-is.
+const LIGHT_MAX_LIGHTNESS = 70
 const DARK_MIN_LIGHTNESS = 60
 
 const darkTone = (seed: Colord): Colord => {
@@ -110,7 +113,7 @@ export function buildScale(seedHex: string): ColorScale {
     Object.entries(SCALE_LIGHTNESS).map(([shade, stepL]) => [shade, channel(h, saturation, stepL)]),
   ) as Omit<ColorScale, 'DEFAULT' | 'foreground'>
 
-  const solid = colord({ h, s: saturation, l })
+  const solid = colord({ h, s: saturation, l: Math.min(l, LIGHT_MAX_LIGHTNESS) })
 
   return {
     ...steps,

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -45,9 +45,8 @@ export type ColorScale = {
   900: string
 }
 
-// Per-step lightness (HSL L%) — the hand-tuned default ramp's near-linear ladder
-// (≈5%/step from 50→900, with `10` a light tint). Generated scales walk this at
-// a fixed saturation and the input hue (see SCALE_SATURATION).
+// Per-step lightness (HSL L%) for the 10…900 tints — the hand-tuned default
+// ramp's near-linear ladder (≈5%/step from 50→900, with `10` a light tint).
 const SCALE_LIGHTNESS: Record<keyof Omit<ColorScale, 'DEFAULT' | 'foreground'>, number> = {
   10: 96,
   50: 80,
@@ -79,47 +78,39 @@ const WHITE = '0 0% 100%'
 const foregroundFor = (c: Colord) =>
   c.contrast('#000000') >= c.contrast('#ffffff') ? BLACK : WHITE
 
-// Generated scales take ONLY the input hue. Saturation is fixed and lightness
-// follows SCALE_LIGHTNESS, so every brand hue yields the same consistent,
-// readable range — in the spirit of Radix's color scales — regardless of how
-// saturated or light the seed was: a neon seed and a muted one at the same hue
-// produce the identical scale. (The built-in ramps work the same way — a
-// constant saturation over a lightness ladder: teal ≈ 23%, orange ≈ 62%.)
-const SCALE_SATURATION = 60
+// Generated scales respect the seed's hue AND lightness — a dark brand color
+// stays dark, a light one stays light — while CAPPING saturation. The cap is the
+// one normalization: a vivid/neon seed is pulled into the muted brand register
+// (the built-in teal ≈ 23%, orange ≈ 62%) so its tints don't read as glaring,
+// while a muted or neutral seed passes through untouched (`min(s, 60)`, so e.g. a
+// gray stays gray). The 10…900 tints walk the fixed lightness ladder; the DEFAULT
+// is the brand color itself (capped), lifted to a visible tone in dark mode.
+const MAX_SATURATION = 60
 
-// A near-achromatic seed (e.g. charcoal #333) has no meaningful hue — colord
-// reports h=0 — so pinning it to the fixed saturation would invent a vivid red.
-// Below this threshold keep the seed's own (low) saturation so neutrals stay
-// neutral; anything chromatic is pinned to SCALE_SATURATION.
-const NEUTRAL_THRESHOLD = 10
+// In dark mode the solid is lifted to at least this lightness so a dark brand
+// color stays visible on the dark canvas.
+const DARK_MIN_LIGHTNESS = 60
 
-const scaleSaturation = (seedSaturation: number) =>
-  seedSaturation < NEUTRAL_THRESHOLD ? seedSaturation : SCALE_SATURATION
+const darkTone = (seed: Colord): Colord => {
+  const { h, s, l } = seed.toHsl()
 
-// The solid brand color (DEFAULT). In light mode it sits at the 400 step,
-// matching the built-in teal/orange whose DEFAULT is their own 400; in dark mode
-// it shifts to a lighter step so it stays visible on the dark canvas.
-const DEFAULT_LIGHTNESS = SCALE_LIGHTNESS[400]
-const DARK_DEFAULT_LIGHTNESS = SCALE_LIGHTNESS[200]
+  return colord({ h, s: Math.min(s, MAX_SATURATION), l: Math.max(l, DARK_MIN_LIGHTNESS) })
+}
 
-const darkTone = (h: number, saturation: number): Colord =>
-  colord({ h, s: saturation, l: DARK_DEFAULT_LIGHTNESS })
-
-// Derive a NextUI color scale from a seed hex using essentially its hue: the
-// 10…900 steps walk SCALE_LIGHTNESS at a fixed saturation (a near-neutral seed
-// keeps its own low saturation; see scaleSaturation), the DEFAULT is the
-// 400-step solid, and `foreground` is its readable on-color. Mode-aware
-// DEFAULT/foreground for dark mode are computed in applyPalette; this scale is
-// the light-mode/canonical form.
+// Derive a NextUI color scale from a seed hex, respecting its hue + lightness and
+// capping saturation: the 10…900 tints walk SCALE_LIGHTNESS at the (capped) seed
+// saturation, the DEFAULT is the brand color itself, and `foreground` is its
+// readable on-color. Mode-aware DEFAULT/foreground for dark mode are computed in
+// applyPalette; this scale is the light-mode/canonical form.
 export function buildScale(seedHex: string): ColorScale {
-  const { h, s } = colord(seedHex).toHsl()
-  const saturation = scaleSaturation(s)
+  const { h, s, l } = colord(seedHex).toHsl()
+  const saturation = Math.min(s, MAX_SATURATION)
 
   const steps = Object.fromEntries(
-    Object.entries(SCALE_LIGHTNESS).map(([shade, l]) => [shade, channel(h, saturation, l)]),
+    Object.entries(SCALE_LIGHTNESS).map(([shade, stepL]) => [shade, channel(h, saturation, stepL)]),
   ) as Omit<ColorScale, 'DEFAULT' | 'foreground'>
 
-  const solid = colord({ h, s: saturation, l: DEFAULT_LIGHTNESS })
+  const solid = colord({ h, s: saturation, l })
 
   return {
     ...steps,
@@ -141,9 +132,8 @@ const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeM
   }
 
   // DEFAULT + foreground are the most visible (bg-primary / text-primary). Dark
-  // mode shifts the solid to a lighter tone so it stays visible on the dark canvas.
-  const { h, s } = seed.toHsl()
-  const tone = mode === 'dark' ? darkTone(h, scaleSaturation(s)) : null
+  // mode lifts the solid to a lighter tone so it stays visible on the dark canvas.
+  const tone = mode === 'dark' ? darkTone(seed) : null
   const base = tone ? toChannel(tone) : scale.DEFAULT
   const foreground = tone ? foregroundFor(tone) : scale.foreground
 

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -81,6 +81,19 @@ const WHITE = '0 0% 100%'
 const foregroundFor = (c: Colord) =>
   c.contrast('#000000') >= c.contrast('#ffffff') ? BLACK : WHITE
 
+// The brand palette is deliberately muted (the default teal sits near 23%
+// saturation, orange near 63%). A very saturated seed — e.g. a vivid green —
+// would generate neon shades that read as harsh/glowing next to the rest of the
+// UI and unreadable as tinted text, so cap saturation to keep generated scales
+// in the same calm register. Low-saturation seeds pass through untouched.
+const MAX_SATURATION = 60
+
+const muted = (c: Colord): Colord => {
+  const { h, s, l } = c.toHsl()
+
+  return s <= MAX_SATURATION ? c : colord({ h, s: MAX_SATURATION, l })
+}
+
 // Dark-mode tone shift (Material 3 tonal guidance: preserve hue, raise tone,
 // desaturate slightly) so a dark brand color stays visible on the dark canvas
 // instead of vanishing into it. Lightness is clamped into a mid-high band (any
@@ -97,7 +110,7 @@ const darkTone = (c: Colord): Colord => {
 // readable on-color for the DEFAULT. Mode-aware DEFAULT/foreground for dark mode
 // are computed in applyPalette; this scale is the light-mode/canonical form.
 export function buildScale(seedHex: string): ColorScale {
-  const seed = colord(seedHex)
+  const seed = muted(colord(seedHex))
   const { h, s } = seed.toHsl()
 
   const steps = Object.fromEntries(
@@ -126,7 +139,7 @@ const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeM
   // DEFAULT + foreground are the most visible (bg-primary / text-primary). Light
   // mode uses the scale's seed-based values as-is; dark lightens the tone so a
   // dark brand color stays visible on the dark canvas.
-  const tone = mode === 'dark' ? darkTone(seed) : null
+  const tone = mode === 'dark' ? darkTone(muted(seed)) : null
   const base = tone ? toChannel(tone) : scale.DEFAULT
   const foreground = tone ? foregroundFor(tone) : scale.foreground
 

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -87,28 +87,39 @@ const foregroundFor = (c: Colord) =>
 // constant saturation over a lightness ladder: teal ≈ 23%, orange ≈ 62%.)
 const SCALE_SATURATION = 60
 
+// A near-achromatic seed (e.g. charcoal #333) has no meaningful hue — colord
+// reports h=0 — so pinning it to the fixed saturation would invent a vivid red.
+// Below this threshold keep the seed's own (low) saturation so neutrals stay
+// neutral; anything chromatic is pinned to SCALE_SATURATION.
+const NEUTRAL_THRESHOLD = 10
+
+const scaleSaturation = (seedSaturation: number) =>
+  seedSaturation < NEUTRAL_THRESHOLD ? seedSaturation : SCALE_SATURATION
+
 // The solid brand color (DEFAULT). In light mode it sits at the 400 step,
 // matching the built-in teal/orange whose DEFAULT is their own 400; in dark mode
 // it shifts to a lighter step so it stays visible on the dark canvas.
 const DEFAULT_LIGHTNESS = SCALE_LIGHTNESS[400]
 const DARK_DEFAULT_LIGHTNESS = SCALE_LIGHTNESS[200]
 
-const darkTone = (h: number): Colord =>
-  colord({ h, s: SCALE_SATURATION, l: DARK_DEFAULT_LIGHTNESS })
+const darkTone = (h: number, saturation: number): Colord =>
+  colord({ h, s: saturation, l: DARK_DEFAULT_LIGHTNESS })
 
-// Derive a NextUI color scale from a seed hex using ONLY its hue: the 10…900
-// steps walk SCALE_LIGHTNESS at the fixed SCALE_SATURATION, the DEFAULT is the
+// Derive a NextUI color scale from a seed hex using essentially its hue: the
+// 10…900 steps walk SCALE_LIGHTNESS at a fixed saturation (a near-neutral seed
+// keeps its own low saturation; see scaleSaturation), the DEFAULT is the
 // 400-step solid, and `foreground` is its readable on-color. Mode-aware
 // DEFAULT/foreground for dark mode are computed in applyPalette; this scale is
 // the light-mode/canonical form.
 export function buildScale(seedHex: string): ColorScale {
-  const { h } = colord(seedHex).toHsl()
+  const { h, s } = colord(seedHex).toHsl()
+  const saturation = scaleSaturation(s)
 
   const steps = Object.fromEntries(
-    Object.entries(SCALE_LIGHTNESS).map(([shade, l]) => [shade, channel(h, SCALE_SATURATION, l)]),
+    Object.entries(SCALE_LIGHTNESS).map(([shade, l]) => [shade, channel(h, saturation, l)]),
   ) as Omit<ColorScale, 'DEFAULT' | 'foreground'>
 
-  const solid = colord({ h, s: SCALE_SATURATION, l: DEFAULT_LIGHTNESS })
+  const solid = colord({ h, s: saturation, l: DEFAULT_LIGHTNESS })
 
   return {
     ...steps,
@@ -131,7 +142,8 @@ const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeM
 
   // DEFAULT + foreground are the most visible (bg-primary / text-primary). Dark
   // mode shifts the solid to a lighter tone so it stays visible on the dark canvas.
-  const tone = mode === 'dark' ? darkTone(seed.toHsl().h) : null
+  const { h, s } = seed.toHsl()
+  const tone = mode === 'dark' ? darkTone(h, scaleSaturation(s)) : null
   const base = tone ? toChannel(tone) : scale.DEFAULT
   const foreground = tone ? foregroundFor(tone) : scale.foreground
 

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -136,10 +136,27 @@ const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeM
   return base
 }
 
+// Every inline var applyPalette can write, cleared before each apply so a role
+// dropped between applies — or an invalid value — falls back to the static theme
+// instead of leaving a stale override. (We can't blanket-clear the root's inline
+// style: the widget wrapper carries `display: contents` there.)
+const MANAGED_VARS = [
+  ...['primary', 'secondary'].flatMap((token) => [
+    `--nextui-${token}`,
+    `--nextui-${token}-foreground`,
+    ...Object.keys(SCALE_LIGHTNESS).map((shade) => `--nextui-${token}-${shade}`),
+  ]),
+  '--nextui-focus',
+  '--nextui-background',
+]
+
 // Repaint a root element in the supplied palette by writing NextUI's CSS vars
-// inline. Omitted roles are left untouched (built-in default stands). `mode`
-// drives the DEFAULT/foreground tone and gates the background override.
+// inline. Resets to the static theme first, then layers on only the supplied
+// roles, so omitted roles fall back to the built-in default. `mode` drives the
+// DEFAULT/foreground tone and gates the background override.
 export function applyPalette(root: HTMLElement, palette: PaletteRoles, mode: ThemeMode) {
+  for (const name of MANAGED_VARS) root.style.removeProperty(name)
+
   if (palette.primary) {
     const primaryDefault = setRole(root, 'primary', palette.primary, mode)
 
@@ -149,15 +166,11 @@ export function applyPalette(root: HTMLElement, palette: PaletteRoles, mode: The
 
   if (palette.secondary) setRole(root, 'secondary', palette.secondary, mode)
 
-  // The background override applies to light mode only; dark keeps its dark
-  // neutral, so we clear any previously-set value when flipping to dark.
+  // The background override applies to light mode only; dark keeps its (already
+  // cleared) dark neutral, and an invalid value fails closed to the default.
   const background = palette.background ? colord(palette.background) : null
 
-  if (background?.isValid()) {
-    if (mode === 'light') {
-      root.style.setProperty('--nextui-background', toChannel(background))
-    } else {
-      root.style.removeProperty('--nextui-background')
-    }
+  if (background?.isValid() && mode === 'light') {
+    root.style.setProperty('--nextui-background', toChannel(background))
   }
 }

--- a/src/hooks/use-theme.test.ts
+++ b/src/hooks/use-theme.test.ts
@@ -1,27 +1,35 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { applyTheme, initTheme } from './use-theme'
+import { applyTheme, initTheme, getInitialTheme, setThemeRoot } from './use-theme'
 
 // The unit lane is node-only (no jsdom — see .claude/rules/tests.md), so we stub
-// the minimal `<html>` classList surface and `localStorage` that the theme
-// helpers touch, then assert their DOM-light contracts directly.
-function stubDocument() {
+// the minimal classList surface and `localStorage` that the theme helpers touch,
+// then assert their DOM-light contracts directly.
+function fakeElement() {
   const classes = new Set<string>()
 
-  vi.stubGlobal('document', {
-    documentElement: {
+  return {
+    classes,
+    el: {
       classList: {
         add: (c: string) => classes.add(c),
         remove: (...cs: string[]) => cs.forEach((c) => classes.delete(c)),
         contains: (c: string) => classes.has(c),
       },
-    },
-  })
+    } as unknown as HTMLElement,
+  }
+}
+
+function stubDocument() {
+  const { classes, el } = fakeElement()
+
+  vi.stubGlobal('document', { documentElement: el })
 
   return classes
 }
 
 afterEach(() => {
+  setThemeRoot(null) // reset the root override so tests don't leak into each other
   vi.unstubAllGlobals()
 })
 
@@ -36,6 +44,30 @@ describe('applyTheme', () => {
     applyTheme('light')
     expect(classes.has('light')).toBe(true)
     expect(classes.has('dark')).toBe(false)
+  })
+})
+
+describe('setThemeRoot', () => {
+  it('directs applyTheme at the configured root instead of <html>', () => {
+    const html = stubDocument()
+    const { classes: widget, el } = fakeElement()
+
+    setThemeRoot(el)
+    applyTheme('dark')
+
+    expect(widget.has('dark')).toBe(true)
+    expect(html.has('dark')).toBe(false) // host page <html> untouched
+  })
+
+  it('reverts to <html> when cleared with null', () => {
+    const html = stubDocument()
+    const { el } = fakeElement()
+
+    setThemeRoot(el)
+    setThemeRoot(null)
+    applyTheme('dark')
+
+    expect(html.has('dark')).toBe(true)
   })
 })
 
@@ -76,5 +108,22 @@ describe('initTheme', () => {
 
     expect(() => initTheme()).not.toThrow()
     expect(classes.has('light')).toBe(true)
+  })
+})
+
+describe('getInitialTheme', () => {
+  it('returns the persisted theme', () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'dark', setItem: () => {} })
+    expect(getInitialTheme()).toBe('dark')
+  })
+
+  it('falls back to the default when nothing is stored', () => {
+    vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {} })
+    expect(getInitialTheme('dark')).toBe('dark')
+  })
+
+  it('ignores a garbage stored value', () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'chartreuse', setItem: () => {} })
+    expect(getInitialTheme()).toBe('light')
   })
 })

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -110,7 +110,7 @@ export const getInitialTheme = (defaultTheme: Theme = ThemeProps.light): Theme =
 export const initTheme = (defaultTheme: Theme = ThemeProps.light) => {
   if (typeof document === 'undefined') return
 
-  applyTheme(readStoredTheme() ?? defaultTheme)
+  applyTheme(getInitialTheme(defaultTheme))
 }
 
 export const useTheme = () => {

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -18,7 +18,9 @@ type Theme = typeof ThemeProps.light | typeof ThemeProps.dark
 // page's <html> — its brand vars and theme class stay inside the widget.
 let themeRoot: HTMLElement | null = null
 
-const getThemeRoot = (): HTMLElement => themeRoot ?? document.documentElement
+// The element the theme machinery reads/writes — the single source of truth for
+// "what is the theme root", shared by useTheme and BrandTheme's palette paint.
+export const getThemeRoot = (): HTMLElement => themeRoot ?? document.documentElement
 
 // Subscriptions that must re-observe when the root element changes (see
 // subscribe). A Set so each live useTheme caller re-attaches its observer.

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,5 +1,5 @@
-// originally written by @imoaazahmed; reworked to observe the root class so a
-// single theme signal drives NextUI, Tailwind, and the Mapbox basemap.
+// originally written by @imoaazahmed; reworked to observe a configurable root
+// class so a single theme signal drives NextUI, Tailwind, and the Mapbox basemap.
 
 import { useSyncExternalStore } from 'react'
 
@@ -11,20 +11,56 @@ const ThemeProps = {
 
 type Theme = typeof ThemeProps.light | typeof ThemeProps.dark
 
-// The root <html> class is the single source of truth: NextUI, Tailwind
+// The theme root's class is the single source of truth: NextUI, Tailwind
 // (darkMode: 'class'), and the Mapbox basemap (MAP_STYLES[theme]) all key off
-// it. useTheme observes the class so every consumer reacts to a change made
-// anywhere — ThemeSwitch, the Ladle theme toggle, etc.
+// it. Standalone, the root is the host page's <html>. Embedded, the widget
+// scopes it to its own wrapper (via setThemeRoot) so it never mutates the host
+// page's <html> — its brand vars and theme class stay inside the widget.
+let themeRoot: HTMLElement | null = null
+
+const getThemeRoot = (): HTMLElement => themeRoot ?? document.documentElement
+
+// Subscriptions that must re-observe when the root element changes (see
+// subscribe). A Set so each live useTheme caller re-attaches its observer.
+const rootListeners = new Set<() => void>()
+
+// Point the theme machinery at a specific element (the widget wrapper), or pass
+// null to fall back to <html>. Notifies live subscribers so they re-observe the
+// new root and re-read the current theme.
+export const setThemeRoot = (el: HTMLElement | null) => {
+  if (themeRoot === el) return
+  themeRoot = el
+  rootListeners.forEach((notify) => notify())
+}
+
+// useTheme observes the root's class so every consumer reacts to a change made
+// anywhere — ThemeSwitch, the Ladle theme toggle, etc. The observer follows the
+// active root: if setThemeRoot swaps it, each subscription re-attaches.
 const subscribe = (onChange: () => void) => {
-  const observer = new MutationObserver(onChange)
+  let observer: MutationObserver | null = null
 
-  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+  const attach = () => {
+    observer?.disconnect()
+    observer = new MutationObserver(onChange)
+    observer.observe(getThemeRoot(), { attributes: true, attributeFilter: ['class'] })
+  }
 
-  return () => observer.disconnect()
+  const onRootChange = () => {
+    attach()
+    onChange()
+  }
+
+  rootListeners.add(onRootChange)
+  attach()
+
+  return () => {
+    rootListeners.delete(onRootChange)
+    observer?.disconnect()
+  }
 }
 
 const getSnapshot = (): Theme =>
-  document.documentElement.classList.contains(ThemeProps.dark) ? ThemeProps.dark : ThemeProps.light
+  getThemeRoot().classList.contains(ThemeProps.dark) ? ThemeProps.dark : ThemeProps.light
 
 // Stories and unit tests render via renderToStaticMarkup (no DOM); default light.
 const getServerSnapshot = (): Theme => ThemeProps.light
@@ -32,7 +68,7 @@ const getServerSnapshot = (): Theme => ThemeProps.light
 // The single seam for writing the theme to the root class — used by useTheme's
 // setters, initTheme, and the Ladle decorator so the mechanism never drifts.
 export const applyTheme = (theme: Theme) => {
-  const root = document.documentElement
+  const root = getThemeRoot()
 
   root.classList.remove(ThemeProps.light, ThemeProps.dark)
   root.classList.add(theme)
@@ -44,7 +80,9 @@ export const applyTheme = (theme: Theme) => {
 // still updates; the choice just isn't persisted.
 const readStoredTheme = (): Theme | null => {
   try {
-    return localStorage.getItem(ThemeProps.key) as Theme | null
+    const stored = localStorage.getItem(ThemeProps.key)
+
+    return stored === ThemeProps.dark || stored === ThemeProps.light ? stored : null
   } catch {
     return null
   }
@@ -57,6 +95,12 @@ const persistTheme = (theme: Theme) => {
     // storage unavailable — ignore; the root class still reflects the choice
   }
 }
+
+// Resolve the theme to render on first paint (persisted choice, else default)
+// without touching the DOM — used by the widget to set its wrapper's initial
+// class so there's no flash before useTheme/initTheme take over.
+export const getInitialTheme = (defaultTheme: Theme = ThemeProps.light): Theme =>
+  readStoredTheme() ?? defaultTheme
 
 // Apply the persisted (or default) theme to the root class once at startup, so
 // the standalone app and widget restore the user's choice. Afterwards useTheme's

--- a/src/providers.tsx
+++ b/src/providers.tsx
@@ -13,6 +13,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <HelmetProvider>
+          {/* Known follow-up: NextUI overlays (Modal/Dropdown/Popover) portal to
+              document.body by default — outside the brand-themed wrapper — so in
+              the embedded widget they don't inherit the wrapper-scoped CSS vars
+              or light/dark class. There's no global portalContainer on
+              NextUIProvider; the fix is to pass each overlay a portalContainer
+              pointing at the widget wrapper (see src/config/theme/BrandTheme). */}
           <NextUIProvider navigate={navigate} useHref={useHref}>
             {children}
           </NextUIProvider>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,9 +12,17 @@
   @apply shadow-md;
 }
 
+/* Resolve the active-bullet color HERE — inside the themed wrapper — so it picks
+   up the widget's brand primary rather than :root's default theme value. Inactive
+   bullets use the theme foreground so they stay visible in both light and dark. */
+.swiper {
+  --swiper-theme-color: hsl(var(--nextui-primary));
+  --swiper-pagination-bullet-inactive-color: hsl(var(--nextui-foreground));
+  --swiper-pagination-bullet-inactive-opacity: 0.4;
+}
+
 @layer base {
   :root {
-    --swiper-theme-color: hsl(var(--nextui-primary));
     --swiper-pagination-bottom: 1rem;
     --swiper-pagination-bullet-width: 5rem;
     --swiper-pagination-bullet-height: 1rem;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -245,6 +245,10 @@ module.exports = {
           large: '28px', // text-large
         },
       },
+      // `danger` is intentionally left to NextUI's built-in red: it's a fixed
+      // status hue that must stay independent of the brand's `secondary`
+      // (orange) — and of any tenant palette, which only overrides
+      // primary/secondary/background at runtime (see src/config/theme/palette.ts).
       themes: {
         light: {
           colors: {
@@ -256,31 +260,25 @@ module.exports = {
               ...ORANGE_COLOR,
               foreground: '#000000',
             },
-            danger: {
-              ...ORANGE_COLOR,
-            },
             focus: TEAL_COLOR,
           },
         },
         dark: {
-          // NextUI's `extend` takes a base-theme *name* (string); nesting colors
-          // under it silently drops them, so the custom dark palette never
-          // applied. Mirror the light theme: put colors at the theme level so
-          // they merge onto NextUI's built-in dark base.
+          // Keep the brand hue in dark mode — no teal↔orange swap. Primary stays
+          // teal and secondary stays orange so a brand color reads the same in
+          // both modes; NextUI's built-in dark base still supplies the neutral
+          // surfaces. (Colors live at the theme level, not under `extend`, which
+          // takes a base-theme *name* and would silently drop a nested palette.)
           colors: {
             primary: {
-              ...ORANGE_COLOR,
-              foreground: '#FFFFFF',
-            },
-            secondary: {
               ...TEAL_COLOR,
               foreground: '#000000',
             },
-            danger: {
+            secondary: {
               ...ORANGE_COLOR,
               foreground: '#000000',
             },
-            focus: ORANGE_COLOR,
+            focus: TEAL_COLOR,
           },
         },
       },


### PR DESCRIPTION
## Summary

Lets each host site render `<syatlas-map>` in its own brand colors from a single
embed snippet, without changing the default build.

- **Runtime theming**: a tenant supplies up to three seed hexes (per-embed props
  `primary-color`/`secondary-color`/`background-color`, or the client record's
  `color1/2/3`). A generator derives a NextUI color scale and writes the
  `--nextui-*` HSL-channel CSS vars **inline on the widget's own wrapper**,
  repainting chips, buttons, links, active nav, panels, and the carousel pills.
- **Resolved per role** as `prop ?? client-record ?? built-in default`. With no
  palette supplied, nothing runs and today's teal/orange build is unchanged.
- **Host-isolated**: the embedded widget scopes its theme class + brand vars to
  its wrapper and never mutates the host page's `<html>`.

## Generation model

The scale **respects the seed's hue and lightness, and caps saturation** at 60%.
Capping is the one normalization — a vivid/neon seed is pulled into the muted
brand register so its tints don't read as glaring — while dark, muted, and
neutral seeds pass through faithfully (so e.g. sahajayoga's dark olive green
stays dark and muted, not a flat medium green). The DEFAULT solid is the brand
color itself, lifted to a visible tone in dark mode (and capped against
near-white on the light canvas — a symmetric guard). The 10…900 tints walk a
fixed lightness ladder; the background override is the tenant's literal surface
color (light mode only). Brand seeds are expected as hex.

## Changes

- `src/config/theme/palette.ts` (+test) — `buildScale`/`applyPalette`; hue +
  lightness respected, saturation capped; clears managed vars before each apply.
- `src/config/theme/BrandTheme.tsx` — resolves + paints the palette above the
  Suspense boundary, merges the client record, re-applies on light/dark flip,
  releases the theme root on unmount.
- `src/hooks/use-theme.ts` — configurable theme root (`setThemeRoot`/
  `getThemeRoot`) so the widget scopes theming to its wrapper; `getInitialTheme`.
- `src/Widget.tsx` — color props + r2wc map; a `display:contents` wrapper.
- `src/config/api/index.ts` — `clientQuery` factory shared by AppRouter + BrandTheme.
- `tailwind.config.js` — dark mode keeps the brand hue; `danger` → NextUI red.
- `src/styles/globals.css` — scope `--swiper-theme-color` to `.swiper` so the
  carousel's active pill follows the brand primary (was stuck on the default),
  and key inactive pills to the theme foreground so they're visible in both modes.
- `.ladle/components.tsx` — palette switcher (wemeditate.com / shrimataji.org /
  sahajayoga.org). `colord` added for the color math.

## Verification

- Lint ✓ · Types ✓ · Tests ✓ 100 unit (`pnpm test:run`) · Build ✓ · Ladle ✓
- **Playwright (via Ladle)** across the presets × light/dark: brand hue + lightness
  repaint with readable foregrounds (sahajayoga stays a dark muted green, shrimataji
  a deep maroon), dark mode keeps a visible tone, the cream background applies in
  light only, `danger` stays NextUI red, carousel pills follow the brand and stay
  visible in dark mode, and the host `<html>` is never mutated.
- **`/simplify` + `/code-review` (high) + `/security-review`** across three rounds;
  all findings triaged.

## Notes for reviewer

- **Client colors reuse `color1/2/3`** (already on the client record, previously
  unused) rather than adding new inert fields — client-record theming works today.
- **Two intentional default-build changes** (ticket-requested): dark mode's
  `primary` is teal-ish instead of orange, and `danger` shifts from orange to
  NextUI's red. Light-mode brand surfaces unchanged.
- **Known follow-up — overlay theming.** NextUI overlays (Modal/Dropdown) portal
  to `document.body`, outside the wrapper, so embedded-widget overlays don't
  inherit the wrapper-scoped vars/class. No global `portalContainer` on
  `NextUIProvider`; per-overlay `portalContainer` → the wrapper is the fix. Out of
  scope here (and not live-verifiable — dev client key 403s), deferred to #22 and
  noted in `providers.tsx`.
- **Security**: host-supplied colors are normalized through `colord` (numeric
  channel strings, `isValid()`-gated) — verified against hostile inputs. Brand
  seeds are hex-only (named CSS colors fail closed to the default).

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
