### PR TITLE
fix(event): resolve event image URLs (populate filename + prefix origin)

### DIFF
--- a/src/components/molecules/EventMetadata/EventMetadata.tsx
+++ b/src/components/molecules/EventMetadata/EventMetadata.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
 
 import { useLocale } from '@/hooks/use-locale'
-import { isOnline, lexicalToText, nextOccurrence } from '@/lib/shape'
+import { isOnline, lexicalToText, nextOccurrence, resolveImageUrl } from '@/lib/shape'
 import { Event } from '@/types'
 
 export type EventMetadataProps = {
@@ -19,7 +19,8 @@ export function EventMetadata({ event }: EventMetadataProps) {
   const languageCode = event.languages[0] ?? locale
   const description = lexicalToText(event.description) || 'Free meditation class'
   const startDate = (nextOccurrence(event) ?? event.schedule?.firstDate)?.toISOString()
-  const image = event.images[0]?.url
+  const rawImage = event.images.find((img) => img.url)?.url
+  const image = rawImage ? resolveImageUrl(rawImage) : undefined
 
   const schema: EventSchema = {
     '@type': 'Event',

--- a/src/components/molecules/EventMetadata/EventMetadata.tsx
+++ b/src/components/molecules/EventMetadata/EventMetadata.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
 
 import { useLocale } from '@/hooks/use-locale'
-import { isOnline, lexicalToText, nextOccurrence, resolveImageUrl } from '@/lib/shape'
+import { isOnline, lexicalToText, nextOccurrence } from '@/lib/shape'
 import { Event } from '@/types'
 
 export type EventMetadataProps = {
@@ -19,8 +19,7 @@ export function EventMetadata({ event }: EventMetadataProps) {
   const languageCode = event.languages[0] ?? locale
   const description = lexicalToText(event.description) || 'Free meditation class'
   const startDate = (nextOccurrence(event) ?? event.schedule?.firstDate)?.toISOString()
-  const rawImage = event.images.find((img) => img.url)?.url
-  const image = rawImage ? resolveImageUrl(rawImage) : undefined
+  const image = event.images.find((img) => img.url)?.url ?? undefined
 
   const schema: EventSchema = {
     '@type': 'Event',

--- a/src/components/organisms/EventDetails/EventDetails.tsx
+++ b/src/components/organisms/EventDetails/EventDetails.tsx
@@ -10,7 +10,7 @@ import { ImageCarousel } from '@/components/molecules/ImageCarousel'
 import { Button } from '@/components/atoms/Button'
 import { AnchorIcon } from '@/components/atoms/Icons'
 import { useLocale } from '@/hooks/use-locale'
-import { isOnline, lexicalToHtml, nextOccurrence } from '@/lib/shape'
+import { isOnline, lexicalToHtml, nextOccurrence, resolveImageUrl } from '@/lib/shape'
 import { Event } from '@/types'
 import { Chip } from '@/components/atoms/Chip'
 
@@ -103,13 +103,21 @@ export function EventDetails({ event, basePath }: EventDetailsProps) {
 
   // The image alt doubles as the lightbox caption (today's behavior). Memoized so
   // a stable slides array is threaded to the carousel/lightbox across re-renders.
+  // Skip images without a resolved url and origin-prefix the rest (relative dev
+  // URLs would otherwise 404 against the widget's own host).
   const slides = useMemo(
     () =>
-      event.images.map((image) => ({
-        src: image.url,
-        alt: image.alt ?? undefined,
-        caption: image.alt ?? undefined,
-      })),
+      event.images.flatMap((image) =>
+        image.url
+          ? [
+              {
+                src: resolveImageUrl(image.url),
+                alt: image.alt ?? undefined,
+                caption: image.alt ?? undefined,
+              },
+            ]
+          : [],
+      ),
     [event.images],
   )
 
@@ -122,7 +130,7 @@ export function EventDetails({ event, basePath }: EventDetailsProps) {
         <h1
           className={`
           text-[24px] font-semibold leading-7 tracking-wide
-          ${event.images.length > 0 ? '' : 'mt-3'}
+          ${slides.length > 0 ? '' : 'mt-3'}
         `}
         >
           {event.title}

--- a/src/components/organisms/EventDetails/EventDetails.tsx
+++ b/src/components/organisms/EventDetails/EventDetails.tsx
@@ -10,7 +10,7 @@ import { ImageCarousel } from '@/components/molecules/ImageCarousel'
 import { Button } from '@/components/atoms/Button'
 import { AnchorIcon } from '@/components/atoms/Icons'
 import { useLocale } from '@/hooks/use-locale'
-import { isOnline, lexicalToHtml, nextOccurrence, resolveImageUrl } from '@/lib/shape'
+import { isOnline, lexicalToHtml, nextOccurrence } from '@/lib/shape'
 import { Event } from '@/types'
 import { Chip } from '@/components/atoms/Chip'
 
@@ -103,15 +103,14 @@ export function EventDetails({ event, basePath }: EventDetailsProps) {
 
   // The image alt doubles as the lightbox caption (today's behavior). Memoized so
   // a stable slides array is threaded to the carousel/lightbox across re-renders.
-  // Skip images without a resolved url and origin-prefix the rest (relative dev
-  // URLs would otherwise 404 against the widget's own host).
+  // URLs are already origin-resolved by getEvent; skip any image that has none.
   const slides = useMemo(
     () =>
       event.images.flatMap((image) =>
         image.url
           ? [
               {
-                src: resolveImageUrl(image.url),
+                src: image.url,
                 alt: image.alt ?? undefined,
                 caption: image.alt ?? undefined,
               },

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -190,3 +190,34 @@ describe('getRegion (unified hierarchy derivation)', () => {
     })
   })
 })
+
+describe('getEvent', () => {
+  // getEvent resolves image URLs at the boundary: SahajCloud serves a relative
+  // `url` in dev, so the fetcher origin-prefixes it. A null url (a file-less
+  // image) is left null for the UI to skip — the boundary never drops images.
+  const rawEvent = {
+    id: 13,
+    title: 'Voronezh Class',
+    eventType: 'offline',
+    languages: ['ru'],
+    registrationMode: 'sahaj-atlas',
+    region: { id: 5, slug: 'voronezh', level: 'city' },
+    images: [
+      { id: 2, filename: 'pic.jpg', url: '/api/images/file/pic.jpg', alt: 'Hall' },
+      { id: 3, url: null, alt: 'no file' },
+    ],
+  }
+
+  it('resolves relative image URLs against the origin, leaving null urls null', async () => {
+    get.mockResolvedValue({ data: rawEvent })
+
+    const event = await api.getEvent(13)
+
+    // Absolute after resolution, without coupling to a specific origin (the dev
+    // `.env.local` and CI `.env` set different SahajCloud URLs).
+    expect(event.images[0].url).toMatch(/^https?:\/\/.*\/api\/images\/file\/pic\.jpg$/)
+    // Null stays null (the UI skips it); the boundary maps, it doesn't filter.
+    expect(event.images[1].url).toBeNull()
+    expect(event.images).toHaveLength(2)
+  })
+})

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -310,7 +310,10 @@ const getEvent = async (id: number): Promise<Event> => {
       },
       populate: {
         ...REGION_POPULATE,
-        images: { url: true, thumbnailURL: true, alt: true },
+        // `url` is a virtual field SahajCloud derives from `filename`, so we must
+        // select `filename` or `url` comes back null. `thumbnailURL` doesn't exist
+        // on this collection (Cloudflare Images flexible variants replaced sizes).
+        images: { url: true, filename: true, alt: true },
       },
     },
   })

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -21,6 +21,7 @@ import {
   eventsUnder,
   childRoute,
   parentOf,
+  resolveImageUrl,
   safePath,
 } from '@/lib/shape'
 import {
@@ -320,7 +321,16 @@ const getEvent = async (id: number): Promise<Event> => {
 
   const event = EventDocSchema.parse(response.data)
 
-  return { ...event, path: safePath(event.webPath) ?? `/${event.id}` }
+  return {
+    ...event,
+    // Resolve image URLs at the data boundary so every consumer gets a ready-to-use
+    // absolute URL (SahajCloud serves relative image URLs in dev) — the same kind of
+    // wire-quirk shaping as `path` below. Null urls stay null; the UI skips them.
+    images: event.images.map((image) =>
+      image.url ? { ...image, url: resolveImageUrl(image.url) } : image,
+    ),
+    path: safePath(event.webPath) ?? `/${event.id}`,
+  }
 }
 
 // ── Widget bootstrap (client config + atlas-wide defaults) ───────────────────────

--- a/src/lib/shape/image.test.ts
+++ b/src/lib/shape/image.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+
+import { resolveImageUrl } from './image'
+
+const ORIGIN = 'https://cloud.sydevelopers.com'
+
+describe('resolveImageUrl', () => {
+  it('prefixes a relative dev URL with the SahajCloud origin', () => {
+    expect(resolveImageUrl('/api/images/file/pic.jpg', ORIGIN)).toBe(
+      'https://cloud.sydevelopers.com/api/images/file/pic.jpg',
+    )
+  })
+
+  it('leaves an already-absolute CDN URL unchanged', () => {
+    const cdn = 'https://imagedelivery.net/abc123/pic.jpg/public'
+
+    expect(resolveImageUrl(cdn, ORIGIN)).toBe(cdn)
+  })
+
+  it('defaults the origin to VITE_SAHAJCLOUD_URL', () => {
+    // Env-driven default (loaded from .env in the vitest env) — assert it yields
+    // an absolute URL carrying the relative path, without coupling to a specific
+    // origin (a dev `.env.local` may point elsewhere).
+    const resolved = resolveImageUrl('/api/images/file/pic.jpg')
+
+    expect(resolved).toMatch(/^https?:\/\//)
+    expect(resolved.endsWith('/api/images/file/pic.jpg')).toBe(true)
+  })
+})

--- a/src/lib/shape/image.test.ts
+++ b/src/lib/shape/image.test.ts
@@ -17,19 +17,25 @@ describe('resolveImageUrl', () => {
     expect(resolveImageUrl(cdn, ORIGIN)).toBe(cdn)
   })
 
-  it('falls back to the raw url when the origin is empty (never throws)', () => {
-    // A misconfigured/empty origin must not crash the event read — degrade to the
-    // raw (relative) url so at most one <img> is broken.
-    expect(resolveImageUrl('/api/images/file/pic.jpg', '')).toBe('/api/images/file/pic.jpg')
+  it('rejects a non-http(s) scheme so a hostile url cannot reach a sink', () => {
+    // A `data:`/`javascript:` image url must not flow into <img src> or the
+    // OG/JSON-LD metadata — drop it rather than pass it through.
+    expect(resolveImageUrl('data:text/html,<script>alert(1)</script>', ORIGIN)).toBeNull()
+    expect(resolveImageUrl('javascript:alert(1)', ORIGIN)).toBeNull()
+  })
+
+  it('returns null when the origin is empty, instead of throwing', () => {
+    // A misconfigured/empty origin must not crash the event read; drop the url so
+    // the UI skips it (at most one broken <img>, never a whole-event failure).
+    expect(resolveImageUrl('/api/images/file/pic.jpg', '')).toBeNull()
   })
 
   it('defaults the origin to VITE_SAHAJCLOUD_URL', () => {
-    // Env-driven default (loaded from .env in the vitest env) — assert it yields
-    // an absolute URL carrying the relative path, without coupling to a specific
-    // origin (a dev `.env.local` may point elsewhere).
-    const resolved = resolveImageUrl('/api/images/file/pic.jpg')
-
-    expect(resolved).toMatch(/^https?:\/\//)
-    expect(resolved.endsWith('/api/images/file/pic.jpg')).toBe(true)
+    // Env-driven default (loaded from .env in the vitest env) — an absolute URL
+    // carrying the relative path, without coupling to a specific origin (a dev
+    // `.env.local` may point elsewhere).
+    expect(resolveImageUrl('/api/images/file/pic.jpg')).toMatch(
+      /^https?:\/\/.*\/api\/images\/file\/pic\.jpg$/,
+    )
   })
 })

--- a/src/lib/shape/image.test.ts
+++ b/src/lib/shape/image.test.ts
@@ -17,6 +17,12 @@ describe('resolveImageUrl', () => {
     expect(resolveImageUrl(cdn, ORIGIN)).toBe(cdn)
   })
 
+  it('falls back to the raw url when the origin is empty (never throws)', () => {
+    // A misconfigured/empty origin must not crash the event read — degrade to the
+    // raw (relative) url so at most one <img> is broken.
+    expect(resolveImageUrl('/api/images/file/pic.jpg', '')).toBe('/api/images/file/pic.jpg')
+  })
+
   it('defaults the origin to VITE_SAHAJCLOUD_URL', () => {
     // Env-driven default (loaded from .env in the vitest env) — assert it yields
     // an absolute URL carrying the relative path, without coupling to a specific

--- a/src/lib/shape/image.ts
+++ b/src/lib/shape/image.ts
@@ -6,7 +6,17 @@
 //
 // Prefix with the origin — not the axios baseURL — because the URL already carries
 // `/api/…` and the client baseURL is `${origin}/api`, which would double the `/api`.
+//
+// Best-effort: if `origin` is empty/misconfigured, `new URL` throws on a relative
+// url — fall back to the raw url so a bad env degrades to a broken <img> rather
+// than failing the whole event read (this runs inside `getEvent`'s image map).
 export const resolveImageUrl = (
   url: string,
-  origin: string = import.meta.env.VITE_SAHAJCLOUD_URL,
-): string => new URL(url, origin).href
+  origin: string | undefined = import.meta.env.VITE_SAHAJCLOUD_URL,
+): string => {
+  try {
+    return new URL(url, origin).href
+  } catch {
+    return url
+  }
+}

--- a/src/lib/shape/image.ts
+++ b/src/lib/shape/image.ts
@@ -1,0 +1,12 @@
+// SahajCloud serves image URLs two ways: absolute in prod (the Cloudflare Images
+// CDN, `https://imagedelivery.net/<hash>/<file>/public`) and relative in dev
+// (`/api/images/file/<file>`). The relative form 404s against the widget's own
+// origin, so resolve it against the SahajCloud origin; an already-absolute URL
+// passes through untouched (`new URL` ignores the base when the input is absolute).
+//
+// Prefix with the origin — not the axios baseURL — because the URL already carries
+// `/api/…` and the client baseURL is `${origin}/api`, which would double the `/api`.
+export const resolveImageUrl = (
+  url: string,
+  origin: string = import.meta.env.VITE_SAHAJCLOUD_URL,
+): string => new URL(url, origin).href

--- a/src/lib/shape/image.ts
+++ b/src/lib/shape/image.ts
@@ -7,16 +7,22 @@
 // Prefix with the origin — not the axios baseURL — because the URL already carries
 // `/api/…` and the client baseURL is `${origin}/api`, which would double the `/api`.
 //
-// Best-effort: if `origin` is empty/misconfigured, `new URL` throws on a relative
-// url — fall back to the raw url so a bad env degrades to a broken <img> rather
-// than failing the whole event read (this runs inside `getEvent`'s image map).
+// Returns null — rather than throwing or passing a raw value through — when the
+// url can't be resolved to an http(s) URL: an empty/misconfigured origin (which
+// makes `new URL` throw on a relative url), or a non-http(s) scheme
+// (`data:`/`javascript:`). That keeps one bad image (or a bad env) from failing
+// the whole event read, and stops a hostile CMS image url from smuggling a
+// `</script>` payload into the OG/JSON-LD metadata. `getEvent` and the UI already
+// skip null urls.
 export const resolveImageUrl = (
   url: string,
   origin: string | undefined = import.meta.env.VITE_SAHAJCLOUD_URL,
-): string => {
+): string | null => {
   try {
-    return new URL(url, origin).href
+    const resolved = new URL(url, origin)
+
+    return resolved.protocol === 'https:' || resolved.protocol === 'http:' ? resolved.href : null
   } catch {
-    return url
+    return null
   }
 }

--- a/src/lib/shape/index.ts
+++ b/src/lib/shape/index.ts
@@ -1,4 +1,5 @@
 export * from './event'
 export * from './hierarchy'
+export * from './image'
 export * from './lexical'
 export * from './path'

--- a/src/mocks/events.ts
+++ b/src/mocks/events.ts
@@ -6,12 +6,10 @@ import type { Event, EventImage, EventSlim, RegionRef } from '@/types'
 export const mockEventImages: EventImage[] = [
   {
     url: 'https://picsum.photos/seed/atlas-hall/1200/800',
-    thumbnailURL: 'https://picsum.photos/seed/atlas-hall/400/300',
     alt: 'Meditation hall',
   },
   {
     url: 'https://picsum.photos/seed/atlas-group/1200/800',
-    thumbnailURL: 'https://picsum.photos/seed/atlas-group/400/300',
     alt: 'Group session',
   },
 ]

--- a/src/types/event.test.ts
+++ b/src/types/event.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { EventSchema, EventSlimSchema, FeedEventSchema } from './event'
+import { EventDocSchema, EventSchema, EventSlimSchema, FeedEventSchema } from './event'
 
 import { mockEvent, mockEventSlim, mockEventSlimList } from '@/mocks/events'
 
@@ -61,5 +61,32 @@ describe('EventSchema', () => {
 
   it('rejects a missing required field', () => {
     expect(() => EventSchema.parse({ ...mockEvent, title: undefined })).toThrow()
+  })
+})
+
+describe('EventDocSchema images', () => {
+  // The real wire shape: `getEvent` selects `filename` (so SahajCloud's virtual
+  // `url` resolves) and the dev backend returns a relative `url`. `filename` is
+  // not part of the schema — it's dropped — and `url` is retained as-is.
+  it('parses an image with filename + relative url, keeping url and dropping filename', () => {
+    const parsed = EventDocSchema.parse({
+      ...mockEvent,
+      images: [
+        { id: 2, filename: 'picture-9.jpg', url: '/api/images/file/picture-9.jpg', alt: 'Hall' },
+      ],
+    })
+
+    expect(parsed.images[0].url).toBe('/api/images/file/picture-9.jpg')
+    expect(parsed.images[0]).not.toHaveProperty('filename')
+    expect(parsed.images[0].alt).toBe('Hall')
+  })
+
+  it('tolerates a null image url so a file-less image cannot crash the event read', () => {
+    const parsed = EventDocSchema.parse({
+      ...mockEvent,
+      images: [{ id: 3, url: null, alt: 'no file' }],
+    })
+
+    expect(parsed.images[0].url).toBeNull()
   })
 })

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -39,10 +39,12 @@ export const EventScheduleSchema = z.object({
 })
 export type EventSchedule = z.infer<typeof EventScheduleSchema>
 
-// Populated `images` upload (the SahajCloud `Image` collection).
+// Populated `images` upload (the SahajCloud `Image` collection). `url` is a
+// virtual field derived from `filename` (which `getEvent` selects); it is nullish
+// so a single file-less image can't fail the whole event read — consumers skip
+// images without a url (mirrors the `SafeUrlSchema` / `firstDate_tz` tolerance).
 export const EventImageSchema = z.object({
-  url: z.string(),
-  thumbnailURL: z.string().nullish(),
+  url: z.string().nullish(),
   alt: z.string().nullish(),
 })
 export type EventImage = z.infer<typeof EventImageSchema>


### PR DESCRIPTION
## Summary

- Event detail views crashed on the `ErrorBoundary` for any event **with images**: `getEvent` populated the image `url` (a SahajCloud virtual field derived from `filename`) without selecting `filename`, so `url` came back `null` and failed the `z.string()` parse. Selecting `filename` makes the virtual `url` resolve; `thumbnailURL` (which doesn't exist on the collection) is dropped.
- Images now actually **display**: resolved dev URLs are relative (`/api/images/file/…`) and 404 against the widget's own origin, so image URLs are origin-prefixed against the SahajCloud origin (absolute prod CDN URLs pass through). Resolution happens once at the data boundary (`getEvent`), so the carousel, lightbox, and OG/JSON-LD metadata all get ready-to-use absolute URLs.
- Hardened so a single file-less image — or a hostile CMS value — can't take down the whole event read.

## Changes

- `src/config/api/fetch.ts` — `getEvent` selects `filename` (drops `thumbnailURL`) and resolves each image URL in its return shaping, next to the existing `path` derivation.
- `src/lib/shape/image.ts` (new) — `resolveImageUrl(url, origin)` → `string | null`: origin-prefixes relative URLs, passes absolute ones through, and drops non-http(s) schemes / unresolvable urls.
- `src/types/event.ts` — `EventImageSchema` drops `thumbnailURL` and makes `url` nullish (a file-less image no longer fails the parse).
- `src/components/organisms/EventDetails/EventDetails.tsx`, `src/components/molecules/EventMetadata/EventMetadata.tsx` — consume the already-resolved URL and skip images without one.

## Verification

- Lint: ✓ (`pnpm lint`)
- Types: ✓ (`pnpm typecheck`)
- Tests: ✓ Unit lane green — 127 tests (`pnpm test:run`), incl. the URL helper (relative-prefix / absolute passthrough / scheme rejection / empty-origin), `EventDocSchema` parsing the real `filename`+relative-`url` shape and tolerating a null url, and `getEvent` resolving image URLs at the boundary.
- Build: deferred to CI (production build + `ladle:build`) — TypeScript/logic-only change, no new deps or config.
- Live-backend data check: confirmed against the running local backend (`curl`, bypassing browser CORS) that the image `url` resolves **only** when `filename` is selected — the exact root cause.

## Manual / visual verification (please confirm)

The in-browser render check couldn't be completed in this session: the local SahajCloud backend (`:3000`) rejects the Vite dev origin (`:5173`) with a CORS preflight failure on `/api/clients/me` — a pre-existing backend config condition, unrelated to this change — so the widget hits its Network-Error boundary before any event renders. Once the backend allows the dev origin, please confirm:

1. Open an event that has images, e.g. `/russia/voronezh/13` — the detail view renders without hitting the `ErrorBoundary`.
2. The images display in the carousel + lightbox (URLs resolve to the SahajCloud origin in dev / the CDN in prod — no 404 against the widget's own origin).

## Notes for reviewer

- **Altitude:** URL resolution lives at the data boundary (`getEvent`), not the UI call-sites — the same place `path` is derived to normalize a SahajCloud wire quirk. Components no longer depend on `VITE_SAHAJCLOUD_URL`, and any future `image.url` consumer is correct by default. The raw `EventDocSchema` stays wire-faithful (resolution happens after parse).
- **Security (fixed in this PR):** `resolveImageUrl` is scheme-gated to `http(s)` and returns `null` for `data:`/`javascript:` schemes or an empty/misconfigured origin — so a hostile CMS image url can't smuggle a `</script>` payload into the OG/JSON-LD metadata, and a bad env degrades to a skipped image rather than a crash.
- **⚠️ Pre-existing security follow-up (separate ticket recommended — NOT fixed here):** `EventMetadata` embeds `JSON.stringify(schema)` in a `<script type="application/ld+json">` (unchanged by this PR). `JSON.stringify` doesn't escape `<`/`>`, and react-helmet commits `<script>` children via `innerHTML`, so a CMS string containing `</script>…` in `event.title` / `description` / address fields is a **stored XSS in the host page's origin**. This PR closes the *image* vector into that sink but deliberately doesn't touch the broader field set. Suggested fix in a focused PR: `JSON.stringify(schema).replace(/</g, '\\u003c')`. Happy to file the ticket.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
