### PR TITLE
fix(ui): follow-up fixes for the nested-drawer navigation UI

### DIFF
--- a/src/Widget.tsx
+++ b/src/Widget.tsx
@@ -3,7 +3,6 @@ import { HashRouter } from 'react-router'
 import { useRef } from 'react'
 
 import App from './App'
-import i18n from './config/i18n'
 import atlasAuth from './config/api/auth'
 import { getInitialTheme } from './hooks/use-theme'
 
@@ -39,9 +38,10 @@ export default function Widget({
     atlasAuth.apiKey = apiKey
   }
 
-  if (locale) {
-    i18n.changeLanguage(locale)
-  }
+  // NB: the initial locale is applied by App's AppShell effect (from `defaultLocale`
+  // below), which runs once on mount and again only if the host changes the prop.
+  // Don't call i18n.changeLanguage here in the render body — it re-fired on every
+  // render and clobbered a language the user picked from the settings menu.
 
   if (!window.location.hash) {
     window.location.hash = HASH_BASE

--- a/src/components/atoms/Drawer/Drawer.tsx
+++ b/src/components/atoms/Drawer/Drawer.tsx
@@ -26,9 +26,9 @@ const drawer = tv({
     body: 'min-h-0 flex-1 overflow-y-auto',
     footer: 'mt-auto shrink-0 border-t border-gray-4',
     // Theme the vaul drag handle (its vendored CSS hardcodes a light grey), give it
-    // breathing room from the sheet's rounded top edge and the header below, and a
-    // grab cursor so the drag affordance reads on pointer devices.
-    handle: '!bg-gray-7 my-3 cursor-grab active:cursor-grabbing',
+    // breathing room from the sheet's rounded top edge but sit it close to the header
+    // below, and a grab cursor so the drag affordance reads on pointer devices.
+    handle: '!bg-gray-7 mb-1 mt-2.5 cursor-grab active:cursor-grabbing',
   },
   variants: {
     direction: {

--- a/src/components/atoms/Drawer/Drawer.tsx
+++ b/src/components/atoms/Drawer/Drawer.tsx
@@ -95,6 +95,9 @@ export type DrawerProps = VariantProps<typeof drawer> & {
   modal?: boolean
   /** When false the drawer can't be closed by swipe/Esc/outside (map-less root). */
   dismissible?: boolean
+  /** Restrict dragging to the handle. With no handle rendered (the left panel), this
+   *  makes the drawer undraggable while the close button still dismisses it. */
+  handleOnly?: boolean
   /** Mobile snap points, e.g. `['96px', '336px', 0.97]`. */
   snapPoints?: (number | string)[]
   activeSnapPoint?: number | string | null
@@ -111,6 +114,7 @@ export function Drawer({
   direction = 'bottom',
   modal = false,
   dismissible = true,
+  handleOnly = false,
   contained = false,
   full = false,
   snapPoints,
@@ -126,6 +130,7 @@ export function Drawer({
   const rootProps = {
     direction,
     dismissible,
+    handleOnly,
     modal,
     open,
     onOpenChange,

--- a/src/components/atoms/Drawer/Drawer.tsx
+++ b/src/components/atoms/Drawer/Drawer.tsx
@@ -65,6 +65,12 @@ const drawer = tv({
       false: {},
     },
   },
+  compoundVariants: [
+    // The bottom sheet shows a drag handle that already spaces the header from the
+    // sheet's top edge, so relax the header's top padding for a balanced handle→header
+    // gap. Not when `full` hides the handle (map-less), where the header owns the top.
+    { direction: 'bottom', full: false, class: { header: 'pt-2' } },
+  ],
   defaultVariants: { direction: 'bottom', contained: false, full: false },
 })
 

--- a/src/components/atoms/Drawer/Drawer.tsx
+++ b/src/components/atoms/Drawer/Drawer.tsx
@@ -48,9 +48,9 @@ const drawer = tv({
       // off-screen. The 3dvh bottom padding keeps the footer above the fold at the
       // 0.97 top snap (the last 3% is hidden); `full` cancels it for map-less.
       bottom: {
-        content: 'inset-x-0 bottom-0 h-[100dvh] rounded-t-2xl border-t border-divider pb-[3dvh]',
+        content: 'inset-x-0 bottom-0 h-dvh rounded-t-2xl border-t border-divider pb-[3dvh]',
       },
-      top: { content: 'inset-x-0 top-0 h-[100dvh] rounded-b-2xl border-b border-divider' },
+      top: { content: 'inset-x-0 top-0 h-dvh rounded-b-2xl border-b border-divider' },
     },
     // Map-less: position absolutely within the widget container instead of fixed to
     // the viewport, so the drawer covers only the content area.

--- a/src/components/molecules/DetailRow/DetailRow.stories.tsx
+++ b/src/components/molecules/DetailRow/DetailRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Story, StoryDefault } from '@ladle/react'
+import type { DetailRowBox } from './DetailRow'
 
 import { StoryWrapper, StorySection } from '../../ladle'
 
@@ -8,35 +9,19 @@ import { CallIcon, LocationIcon } from '@/components/atoms/Icons'
 
 export default { title: 'Molecules' } satisfies StoryDefault
 
-// A bare leading-slot icon — the slot's `tone` tints it, so callers don't.
-const Icon = () => (
-  <div className="flex-center h-full">
-    <LocationIcon />
-  </div>
-)
-
-const Phone = () => (
-  <div className="flex-center h-full">
-    <CallIcon size={32} />
-  </div>
-)
-
-// A leading-slot date badge (as the event timing card uses) — a self-styled slot.
-const DateBadge = () => (
-  <>
-    <div className="bg-primary-4 py-0.5 text-xs font-semibold">MAR</div>
-    <div className="flex h-6 items-center justify-center text-md font-semibold text-gray-11">
-      18
-    </div>
-  </>
-)
+// The two leading-box shapes, as the event detail cards use them: a framed icon
+// (location, host contact) and a split top/bottom date badge (timing).
+const iconBox: DetailRowBox = { kind: 'icon', icon: <LocationIcon /> }
+const phoneBox: DetailRowBox = { kind: 'icon', icon: <CallIcon size={32} /> }
+const dateBox: DetailRowBox = { kind: 'split', top: 'MAR', bottom: 18 }
 
 /**
- * DetailRow — a generic labelled row: a leading square slot (icon or badge) then a
- * title over secondary content. The title is plain text, or an internal/external
- * link via `url`/`isExternal`. The slot's `tone` owns its tint — `icon` (default),
- * `highlight` (filled), or `plain` (self-styled, e.g. a date badge). The event
- * detail cards (timing, location, host contact) build on it.
+ * DetailRow — a generic labelled row: a leading square box (a framed icon or a
+ * split top/bottom badge) then a title over secondary content. The title is plain
+ * text, or an internal/external link via `url`/`isExternal`. The `box` prop models
+ * the two shapes explicitly; `tone` owns the icon box's tint — `icon` (default),
+ * `highlight` (filled), or `plain` (the split badge supplies its own colours). The
+ * event detail cards (timing, location, host contact) build on it.
  */
 export const Default: Story = () => (
   <StoryWrapper>
@@ -46,82 +31,83 @@ export const Default: Story = () => (
     >
       <div className="flex max-w-md flex-col gap-6">
         <StorySection title="Plain (no link)" variant="subsection">
-          <DetailRow content="123 Peace Street, London" title="Meditation Centre">
-            <Icon />
-          </DetailRow>
+          <DetailRow box={iconBox} content="123 Peace Street, London" title="Meditation Centre" />
         </StorySection>
 
         <StorySection title="Internal link" variant="subsection">
-          <DetailRow content="See the venue page" title="Cambridge Centre" url="#venue">
-            <Icon />
-          </DetailRow>
+          <DetailRow
+            box={iconBox}
+            content="See the venue page"
+            title="Cambridge Centre"
+            url="#venue"
+          />
         </StorySection>
 
         <StorySection title="External link (isExternal)" variant="subsection">
           <DetailRow
             isExternal
+            box={phoneBox}
             content="Call +44 20 1234 5678"
             title="Contact the host"
             url="tel:+442012345678"
-          >
-            <Phone />
-          </DetailRow>
+          />
         </StorySection>
       </div>
     </StorySection>
 
     <StorySection
-      description="`tone` sets the leading slot's appearance: a tinted icon (default), the brand-filled highlight (the emphasised contact card), or an untinted self-styled slot."
-      title="Tone"
+      description="`box` sets the leading shape (a framed icon or a split date badge); `tone` sets the icon box's appearance: a tinted icon (default), the brand-filled highlight (the emphasised contact card), or an untinted frame."
+      title="Box & tone"
     >
       <div className="flex max-w-md flex-col gap-6">
-        <StorySection title="icon (default)" variant="subsection">
-          <DetailRow content="123 Peace Street, London" title="Meditation Centre">
-            <Icon />
-          </DetailRow>
+        <StorySection title="icon (default tone)" variant="subsection">
+          <DetailRow box={iconBox} content="123 Peace Street, London" title="Meditation Centre" />
         </StorySection>
 
-        <StorySection title="highlight" variant="subsection">
+        <StorySection title="icon — highlight" variant="subsection">
           <DetailRow
             isExternal
+            box={phoneBox}
             content="Call for the next class time"
             title="Contact for timing"
             tone="highlight"
             url="tel:+442012345678"
-          >
-            <Phone />
-          </DetailRow>
+          />
         </StorySection>
 
-        <StorySection title="plain (self-styled slot, e.g. a date badge)" variant="subsection">
-          <DetailRow content="Every Tuesday, 7:00 PM" title="Weekly class" tone="plain">
-            <DateBadge />
-          </DetailRow>
+        <StorySection title="split (date badge, plain tone)" variant="subsection">
+          <DetailRow
+            box={dateBox}
+            content="Every Tuesday, 7:00 PM"
+            title="Weekly class"
+            tone="plain"
+          />
         </StorySection>
       </div>
     </StorySection>
 
     <StorySection inContext={true} title="Examples">
       <div className="flex max-w-md flex-col gap-4">
-        <DetailRow content="Every Tuesday, 7:00 PM" title="Weekly class" tone="plain">
-          <DateBadge />
-        </DetailRow>
+        <DetailRow
+          box={dateBox}
+          content="Every Tuesday, 7:00 PM"
+          title="Weekly class"
+          tone="plain"
+        />
         <DetailRow
           isExternal
+          box={iconBox}
           content="123 Peace Street, London"
           title="Meditation Centre"
           url="#venue"
-        >
-          <Icon />
-        </DetailRow>
+        />
         <DetailRow
           isExternal
+          box={phoneBox}
           content="Call +44 20 1234 5678"
           title="Contact the host"
           url="tel:+442012345678"
-        >
-          <Phone />
-        </DetailRow>
+        />
       </div>
     </StorySection>
 

--- a/src/components/molecules/DetailRow/DetailRow.test.tsx
+++ b/src/components/molecules/DetailRow/DetailRow.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+
+import { DetailRow } from './DetailRow'
+
+// SSR markup assertions (node lane, no jsdom — see .claude/rules/tests.md). The
+// leading box is always square (h-11 w-11) and models exactly two shapes.
+describe('DetailRow', () => {
+  it('renders the icon shape as a square box containing the icon', () => {
+    const html = renderToStaticMarkup(
+      <DetailRow box={{ kind: 'icon', icon: <span>ICON</span> }} content="c" title="t" />,
+    )
+
+    expect(html).toContain('ICON')
+    expect(html).toContain('h-11 w-11')
+  })
+
+  it('renders the split shape with a top band and bottom line', () => {
+    const html = renderToStaticMarkup(
+      <DetailRow
+        box={{ kind: 'split', top: 'JUL', bottom: 14 }}
+        content="c"
+        title="t"
+        tone="plain"
+      />,
+    )
+
+    expect(html).toContain('JUL')
+    expect(html).toContain('14')
+    expect(html).toContain('h-11 w-11') // still square
+    expect(html).toContain('bg-primary-4') // the tinted top band
+  })
+
+  it('fills the box for the highlight tone', () => {
+    const html = renderToStaticMarkup(
+      <DetailRow
+        box={{ kind: 'icon', icon: <span>I</span> }}
+        content="c"
+        title="t"
+        tone="highlight"
+      />,
+    )
+
+    expect(html).toContain('bg-primary-4')
+    expect(html).toContain('text-background')
+  })
+})

--- a/src/components/molecules/DetailRow/DetailRow.tsx
+++ b/src/components/molecules/DetailRow/DetailRow.tsx
@@ -4,24 +4,39 @@ import { tv } from 'tailwind-variants'
 import { AnchorIcon } from '@/components/atoms/Icons'
 import { Link } from '@/components/atoms/Link'
 
-// The leading square slot owns its own tone, so callers just drop a bare icon in:
+// The leading square slot models the two box shapes explicitly so it's always
+// square and consistent — callers pass structured content, not a hand-assembled
+// slot. `tone` owns the box tint for the icon shape:
 // - `icon` (default): a brand-tinted icon (location, host contact).
 // - `highlight`: fill the slot and invert the icon — the emphasised host-contact
 //   card that leads the stack when an event has no upcoming date.
-// - `plain`: a self-styled slot (e.g. the timing date badge), left untinted.
+// - `plain`: an untinted frame (the split date badge supplies its own colours).
 const detailRow = tv({
   slots: {
-    iconBox: 'text-center border border-primary-4 rounded-sm w-11 h-11',
+    // Always square; overflow-hidden clips the split top band to the rounded corners.
+    box: 'h-11 w-11 shrink-0 overflow-hidden rounded-sm border border-primary-4 text-center',
+    // Icon shape: centre the single icon and inherit the box tint.
+    iconSlot: 'flex-center h-full',
+    // Split shape: a tinted top band (e.g. "JUL") over a bottom line (e.g. "14").
+    splitTop: 'bg-primary-4 py-0.5 text-xs font-semibold dark:bg-primary-5',
+    splitBottom: 'flex h-6 items-center justify-center text-md font-semibold text-gray-11',
   },
   variants: {
     tone: {
-      icon: { iconBox: 'text-primary' },
-      highlight: { iconBox: 'bg-primary-4 text-background' },
+      icon: { box: 'text-primary' },
+      highlight: { box: 'bg-primary-4 text-background' },
       plain: {},
     },
   },
   defaultVariants: { tone: 'icon' },
 })
+
+/** The two real leading-box shapes: a framed single icon, or a split top/bottom badge. */
+export type DetailRowBox =
+  | { kind: 'icon'; icon: ReactNode }
+  | { kind: 'split'; top: ReactNode; bottom: ReactNode }
+
+type DetailRowTone = 'icon' | 'highlight' | 'plain'
 
 export type DetailRowProps = {
   /** Primary label; becomes a link when `url` is set. */
@@ -32,21 +47,42 @@ export type DetailRowProps = {
   url?: string
   /** Render the title as an external link (adds the anchor icon + new-tab rel). */
   isExternal?: boolean
-  /** Leading-slot appearance: a tinted icon (default), the highlighted fill, or an untinted slot. */
-  tone?: 'icon' | 'highlight' | 'plain'
-  /** Visual for the leading square slot (an icon, a date badge, etc.). */
-  children: ReactNode
+  /** Leading-box tint for the icon shape: tinted icon (default), highlighted fill, or untinted. */
+  tone?: DetailRowTone
+  /** The leading square box: a framed icon, or a split top/bottom badge. */
+  box: DetailRowBox
+}
+
+// The leading square slot — either a centred icon or a split top/bottom badge.
+function LeadingBox({ box, tone }: { box: DetailRowBox; tone: DetailRowTone }) {
+  const styles = detailRow({ tone })
+
+  if (box.kind === 'split') {
+    return (
+      <div className={styles.box()}>
+        <div className={styles.splitTop()}>{box.top}</div>
+        <div className={styles.splitBottom()}>{box.bottom}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.box()}>
+      <div className={styles.iconSlot()}>{box.icon}</div>
+    </div>
+  )
 }
 
 /**
- * A generic labelled row: a leading square slot, then a title (optionally an
+ * A generic labelled row: a leading square box, then a title (optionally an
  * internal/external link) over secondary content. Presentational only — callers
- * pass the icon/badge and copy. Used to build the event detail cards.
+ * pass a structured `box` and copy. Used to build the event detail cards.
  *
  * Variants:
+ * - `box` — the leading shape: `{ kind: 'icon', icon }` or `{ kind: 'split', top, bottom }`.
  * - `url` + `isExternal` — turn the title into an internal or external link.
- * - `tone` — the leading slot's appearance. The slot owns the icon tint, so
- *   callers pass a bare icon rather than styling it themselves.
+ * - `tone` — the icon box's tint (icon / highlight / plain). The box owns the tint,
+ *   so callers pass a bare icon rather than styling it themselves.
  */
 export function DetailRow({
   isExternal = false,
@@ -54,13 +90,11 @@ export function DetailRow({
   title,
   content,
   url,
-  children,
+  box,
 }: DetailRowProps) {
-  const { iconBox } = detailRow({ tone })
-
   return (
     <div className="flex-center-y gap-3">
-      <div className={iconBox()}>{children}</div>
+      <LeadingBox box={box} tone={tone} />
       <div className="flex flex-col gap-0.5">
         {url ? (
           <Link

--- a/src/components/molecules/DetailRow/DetailRow.tsx
+++ b/src/components/molecules/DetailRow/DetailRow.tsx
@@ -57,20 +57,17 @@ export type DetailRowProps = {
 function LeadingBox({ box, tone }: { box: DetailRowBox; tone: DetailRowTone }) {
   const styles = detailRow({ tone })
 
-  if (box.kind === 'split') {
-    return (
-      <div className={styles.box()}>
+  const inner =
+    box.kind === 'split' ? (
+      <>
         <div className={styles.splitTop()}>{box.top}</div>
         <div className={styles.splitBottom()}>{box.bottom}</div>
-      </div>
-    )
-  }
-
-  return (
-    <div className={styles.box()}>
+      </>
+    ) : (
       <div className={styles.iconSlot()}>{box.icon}</div>
-    </div>
-  )
+    )
+
+  return <div className={styles.box()}>{inner}</div>
 }
 
 /**

--- a/src/components/molecules/DetailRow/index.ts
+++ b/src/components/molecules/DetailRow/index.ts
@@ -1,2 +1,2 @@
 export { DetailRow } from './DetailRow'
-export type { DetailRowProps } from './DetailRow'
+export type { DetailRowProps, DetailRowBox } from './DetailRow'

--- a/src/components/molecules/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/molecules/SettingsMenu/SettingsMenu.tsx
@@ -64,7 +64,7 @@ export function SettingsMenu({ className }: { className?: string }) {
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal container={container}>
-        <DropdownMenu.Content align="end" className={menu} sideOffset={8}>
+        <DropdownMenu.Content align="start" className={menu} sideOffset={8}>
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className={item}>
               <LanguageIcon size={18} />

--- a/src/components/molecules/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/molecules/SettingsMenu/SettingsMenu.tsx
@@ -17,7 +17,7 @@ import { type ThemePreference, useThemePreference } from '@/hooks/use-theme'
 import { overlayContainer } from '@/lib/overlay'
 
 const menu =
-  'z-50 min-w-[11rem] rounded-xl border border-divider bg-background p-1 text-foreground shadow-xl'
+  'z-50 min-w-44 rounded-xl border border-divider bg-background p-1 text-foreground shadow-xl'
 const item =
   'flex cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-2 text-sm outline-none data-[highlighted]:bg-primary-3 data-[state=open]:bg-primary-3'
 
@@ -63,10 +63,10 @@ export function SettingsMenu({
       <DropdownMenu.Trigger asChild>
         <button
           aria-label={t('settings')}
-          className={`flex h-10 w-10 items-center justify-center rounded-full border border-divider bg-background text-gray-11 shadow-lg transition-colors hover:text-foreground ${className ?? ''}`}
+          className={`flex h-8 w-8 items-center justify-center rounded-full border border-divider bg-background text-gray-11 shadow-lg transition-colors hover:text-foreground ${className ?? ''}`}
           type="button"
         >
-          <SettingsIcon size={20} />
+          <SettingsIcon size={16} />
         </button>
       </DropdownMenu.Trigger>
 

--- a/src/components/molecules/SettingsMenu/SettingsMenu.tsx
+++ b/src/components/molecules/SettingsMenu/SettingsMenu.tsx
@@ -38,7 +38,14 @@ function ItemCheck() {
 // on Radix DropdownMenu (Sub / RadioGroup) — one clean menu with submenu flow —
 // replacing the old footer's LanguageSelector + ThemeSwitch. `className` positions
 // the trigger button.
-export function SettingsMenu({ className }: { className?: string }) {
+export function SettingsMenu({
+  className,
+  side = 'bottom',
+}: {
+  className?: string
+  /** Which side the menu opens toward the trigger (bottom for a top cog, top for a bottom cog). */
+  side?: DropdownMenu.DropdownMenuContentProps['side']
+}) {
   const { t } = useTranslation('common')
   const { locale, setLocale, languageNames } = useLocale()
   const { preference, setPreference } = useThemePreference()
@@ -64,7 +71,7 @@ export function SettingsMenu({ className }: { className?: string }) {
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal container={container}>
-        <DropdownMenu.Content align="start" className={menu} sideOffset={8}>
+        <DropdownMenu.Content align="start" className={menu} side={side} sideOffset={8}>
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className={item}>
               <LanguageIcon size={18} />

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -8,7 +8,7 @@ export { LoadingFallback, ErrorFallback } from './Fallbacks'
 
 // DetailRow — a generic labelled icon row; the event detail cards build on it.
 export { DetailRow } from './DetailRow'
-export type { DetailRowProps } from './DetailRow'
+export type { DetailRowProps, DetailRowBox } from './DetailRow'
 
 export { List } from './List'
 

--- a/src/components/organisms/EventDetails/EventDetails.tsx
+++ b/src/components/organisms/EventDetails/EventDetails.tsx
@@ -128,7 +128,7 @@ export function EventDetails({ event, basePath }: EventDetailsProps) {
       <div className="flex flex-col gap-3 px-8 pb-12 pt-3">
         <h1
           className={`
-          text-[24px] font-semibold leading-7 tracking-wide
+          text-2xl font-semibold leading-7 tracking-wide
           ${slides.length > 0 ? '' : 'mt-3'}
         `}
         >
@@ -164,7 +164,7 @@ export function EventDetails({ event, basePath }: EventDetailsProps) {
                 ADD_ATTR: ['target'],
               }),
             }}
-            className="colored-links normal-nums my-2 flex flex-col gap-2 leading-snug"
+            className="colored-links normal-nums my-2 flex flex-col gap-2 text-sm leading-snug"
           />
         )}
         <div className="flex-center-x gap-1">

--- a/src/components/organisms/EventDetails/details.tsx
+++ b/src/components/organisms/EventDetails/details.tsx
@@ -50,16 +50,13 @@ export function EventContactDetails({
 
   return (
     <DetailRow
+      box={{ kind: 'icon', icon: <CallIcon size={32} /> }}
       content={t('details.tel', { phoneNumber: event.contactPhone })}
       isExternal={true}
       title={isHighlighted ? t('details.contact_for_timing') : t('details.contact_host')}
       tone={isHighlighted ? 'highlight' : 'icon'}
       url={`tel: ${event.contactPhone}`}
-    >
-      <div className="flex-center h-full">
-        <CallIcon size={32} />
-      </div>
-    </DetailRow>
+    />
   )
 }
 
@@ -85,6 +82,11 @@ export function EventTimingDetails({
 
   return (
     <DetailRow
+      box={{
+        kind: 'split',
+        top: nextDate.toLocaleString({ month: 'short' }).toUpperCase(),
+        bottom: nextDate.day,
+      }}
       content={
         <EventTime
           endTime={schedule?.endTime}
@@ -105,14 +107,7 @@ export function EventTimingDetails({
           : t('details.contact_for_timing')
       }
       tone="plain"
-    >
-      <div className="text-xs bg-primary-4 dark:bg-primary-5 py-0.5 font-semibold">
-        {nextDate.toLocaleString({ month: 'short' }).toUpperCase()}
-      </div>
-      <div className="flex items-center justify-center font-semibold text-md h-6 text-gray-11">
-        {nextDate.day}
-      </div>
-    </DetailRow>
+    />
   )
 }
 
@@ -141,14 +136,14 @@ export function EventLocationDetails({ event }: { event: Event }) {
 
   return (
     <DetailRow
+      box={{
+        kind: 'icon',
+        icon: platform ? <SocialIcon platform={platform} size={24} /> : <LocationIcon />,
+      }}
       content={subtitle}
       isExternal={true}
       title={title}
       url={online ? (event.onlineUrl ?? undefined) : directionsUrl(event)}
-    >
-      <div className="flex-center h-full">
-        {platform ? <SocialIcon platform={platform} size={24} /> : <LocationIcon />}
-      </div>
-    </DetailRow>
+    />
   )
 }

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -186,6 +186,10 @@ const toListItem = (doc: RegionDoc, events: GeoEvent[]): RegionListItem =>
     path: regionRoute(doc),
   })
 
+// Busiest first — order a region list by event count, descending. A stable sort
+// keeps equal counts in the incoming (server) order.
+const byEventCountDesc = (a: RegionListItem, b: RegionListItem) => b.eventCount - a.eventCount
+
 // ── Hierarchy fetchers (raw region + geojson-derived counts/bounds) ─────────────
 
 // Home/search country list — level=country regions with counts + ISO code.
@@ -219,6 +223,7 @@ const getCountries = async (): Promise<RegionListItem[]> => {
       }),
     )
     .filter((country) => country.eventCount > 0)
+    .sort(byEventCountDesc)
 }
 
 // One fetcher for every region level. `country`/`region` populate `subregions`
@@ -238,6 +243,7 @@ const getRegion = async (slug: string): Promise<Region> => {
     ? (await getChildRegions(doc.id))
         .map((child) => toListItem(child, events))
         .filter((child) => child.eventCount > 0)
+        .sort(byEventCountDesc)
     : []
 
   return RegionSchema.parse({

--- a/src/config/theme/palette.test.ts
+++ b/src/config/theme/palette.test.ts
@@ -135,6 +135,20 @@ describe('applyPalette', () => {
     expect(props.size).toBe(0)
   })
 
+  it('ignores an achromatic seed so the default brand theme stands', () => {
+    const { root, props } = fakeRoot()
+
+    // The local client record defaults color1–3 to #000000. An achromatic primary /
+    // secondary must NOT paint a grey ramp — the roles fall back to the globals.css
+    // default (the built-in teal / orange). Background still snaps to the readable
+    // near-white app-bg step, as it does for any near-black seed.
+    applyPalette(root, { primary: '#000000', secondary: '#000000', background: '#000000' }, 'light')
+
+    expect([...props.keys()].some((k) => k.startsWith('--primary'))).toBe(false)
+    expect([...props.keys()].some((k) => k.startsWith('--secondary'))).toBe(false)
+    expect(props.get('--background')).toBe('0 0% 99%')
+  })
+
   it('clears a role that is dropped on a later apply (reverts to the default)', () => {
     const { root, props } = fakeRoot()
 

--- a/src/config/theme/palette.ts
+++ b/src/config/theme/palette.ts
@@ -139,8 +139,23 @@ export function buildScale(seedHex: string, mode: ThemeMode): ColorScale {
   return scale
 }
 
+// A brand seed must carry a real hue. A fully-desaturated (black / white / grey)
+// seed is the backend's "unconfigured" sentinel — the client record defaults
+// color1–3 to #000000 — not a brand color; painting its ramp washes the whole
+// widget grey (a #000000 seed → a 0%-saturation ramp). So an achromatic seed is
+// treated like an invalid one: the role isn't written and the static globals.css
+// default (the built-in teal / orange) stands. (Background is handled separately —
+// its shade always snaps to the near-white/near-black app-bg step regardless.)
+const MIN_BRAND_SATURATION = 5
+
+const isBrandSeed = (seedHex: string): boolean => {
+  const c = colord(seedHex)
+
+  return c.isValid() && c.toHsl().s >= MIN_BRAND_SATURATION
+}
+
 const setRole = (root: HTMLElement, token: string, seedHex: string, mode: ThemeMode) => {
-  if (!colord(seedHex).isValid()) return false
+  if (!isBrandSeed(seedHex)) return false
 
   const scale = buildScale(seedHex, mode)
 

--- a/src/hooks/use-locale.ts
+++ b/src/hooks/use-locale.ts
@@ -1,26 +1,39 @@
-// originally written by @imoaazahmed
+// originally written by @imoaazahmed; reworked to track i18next's active language
+// reactively (see #35) so every consumer relocalizes together on a language change.
 
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export function useLocale() {
   const { i18n } = useTranslation()
-  const [locale, setLocale] = useState(i18n.resolvedLanguage || 'en')
-  const languageNames = useMemo(() => {
-    return new Intl.DisplayNames(locale, { type: 'language' })
-  }, [locale])
-  const regionNames = useMemo(() => {
-    return new Intl.DisplayNames(locale, { type: 'region' })
-  }, [locale])
+
+  // Subscribe to i18next's `languageChanged` so every consumer re-reads the active
+  // language at once. The old local useState only updated for the instance whose
+  // own setLocale ran, leaving other consumers (e.g. CountriesView's regionNames)
+  // on a stale locale — their Intl.DisplayNames never rebuilt — until they remounted.
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      i18n.on('languageChanged', onChange)
+
+      return () => i18n.off('languageChanged', onChange)
+    },
+    [i18n],
+  )
+  const getSnapshot = useCallback(() => i18n.resolvedLanguage || 'en', [i18n])
+  const locale = useSyncExternalStore(subscribe, getSnapshot, () => 'en')
+
+  const languageNames = useMemo(() => new Intl.DisplayNames(locale, { type: 'language' }), [locale])
+  const regionNames = useMemo(() => new Intl.DisplayNames(locale, { type: 'region' }), [locale])
+
+  // Just change the language; the subscription above re-snapshots every consumer —
+  // no local state to keep in sync.
+  const setLocale = useCallback((next: string) => void i18n.changeLanguage(next), [i18n])
 
   return {
-    locale: locale,
+    locale,
     languageCode: locale.split('-')[0],
     languageNames,
     regionNames,
-    setLocale: (locale: string) => {
-      i18n.changeLanguage(locale)
-      setLocale(locale)
-    },
+    setLocale,
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -101,6 +101,17 @@
   --swiper-pagination-bullet-inactive-opacity: 0.4;
 }
 
+/* vaul disables text selection on the drawer for pointer devices (to keep drag
+   gestures clean — see vaul.css `@media (hover:hover) and (pointer:fine)`). Desktop
+   drag is already disabled (handleOnly on the left panel), so re-enable selection
+   there: event/venue copy should be selectable. Mobile is untouched — vaul only
+   sets user-select:none under hover+fine, so touch drawers stay selectable already. */
+@media (hover: hover) and (pointer: fine) {
+  [data-vaul-drawer] {
+    user-select: text;
+  }
+}
+
 @layer base {
   :root {
     --swiper-pagination-bottom: 1rem;

--- a/src/views/CountriesView/CountriesView.tsx
+++ b/src/views/CountriesView/CountriesView.tsx
@@ -61,7 +61,7 @@ export function CountriesView() {
               >
                 {country.countryCode && (
                   <CircleFlag
-                    className="mr-3 h-9 w-9 rounded-full border border-divider bg-divider"
+                    className="mr-3 h-7 w-7 rounded-full border border-divider bg-divider lg:h-9 lg:w-9"
                     countryCode={country.countryCode.toLocaleLowerCase()}
                   />
                 )}

--- a/src/views/CountriesView/CountriesView.tsx
+++ b/src/views/CountriesView/CountriesView.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
 import { CircleFlag } from 'react-circle-flags'
@@ -33,17 +32,6 @@ export function CountriesView() {
   // Frame the world view when this view mounts.
   useFrameOnTop(() => frameSearch({}), [frameSearch])
 
-  // Only countries with events, busiest first (most events at the top). `.filter`
-  // already returns a fresh array, so sorting it doesn't touch the query cache;
-  // equal counts keep the API order.
-  const rankedCountries = useMemo(
-    () =>
-      countries
-        .filter((country) => country.eventCount > 0)
-        .sort((a, b) => b.eventCount - a.eventCount),
-    [countries],
-  )
-
   const homeUrl = client.region && typeof client.region === 'object' ? client.region.webUrl : null
   const canonicalUrl = validateWebUrl(homeUrl)
 
@@ -62,7 +50,7 @@ export function CountriesView() {
       </DrawerHeader>
       <DrawerBody>
         <List>
-          {rankedCountries.map((country) => (
+          {countries.map((country) => (
             <RegionCard
               key={country.id}
               count={country.eventCount}

--- a/src/views/CountriesView/CountriesView.tsx
+++ b/src/views/CountriesView/CountriesView.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
 import { CircleFlag } from 'react-circle-flags'
@@ -32,6 +33,17 @@ export function CountriesView() {
   // Frame the world view when this view mounts.
   useFrameOnTop(() => frameSearch({}), [frameSearch])
 
+  // Only countries with events, busiest first (most events at the top). `.filter`
+  // already returns a fresh array, so sorting it doesn't touch the query cache;
+  // equal counts keep the API order.
+  const rankedCountries = useMemo(
+    () =>
+      countries
+        .filter((country) => country.eventCount > 0)
+        .sort((a, b) => b.eventCount - a.eventCount),
+    [countries],
+  )
+
   const homeUrl = client.region && typeof client.region === 'object' ? client.region.webUrl : null
   const canonicalUrl = validateWebUrl(homeUrl)
 
@@ -50,23 +62,21 @@ export function CountriesView() {
       </DrawerHeader>
       <DrawerBody>
         <List>
-          {countries
-            .filter((country) => country.eventCount > 0)
-            .map((country) => (
-              <RegionCard
-                key={country.id}
-                count={country.eventCount}
-                href={country.path}
-                label={(country.countryCode && regionNames.of(country.countryCode)) || country.name}
-              >
-                {country.countryCode && (
-                  <CircleFlag
-                    className="mr-3 h-7 w-7 rounded-full border border-divider bg-divider lg:h-9 lg:w-9"
-                    countryCode={country.countryCode.toLocaleLowerCase()}
-                  />
-                )}
-              </RegionCard>
-            ))}
+          {rankedCountries.map((country) => (
+            <RegionCard
+              key={country.id}
+              count={country.eventCount}
+              href={country.path}
+              label={(country.countryCode && regionNames.of(country.countryCode)) || country.name}
+            >
+              {country.countryCode && (
+                <CircleFlag
+                  className="mr-3 h-7 w-7 rounded-full border border-divider bg-divider lg:h-9 lg:w-9"
+                  countryCode={country.countryCode.toLocaleLowerCase()}
+                />
+              )}
+            </RegionCard>
+          ))}
         </List>
       </DrawerBody>
     </>

--- a/src/views/DrawerStack/DrawerStack.tsx
+++ b/src/views/DrawerStack/DrawerStack.tsx
@@ -67,7 +67,7 @@ function TopView({ entry, parentPath }: { entry: StackEntry | null; parentPath: 
 // with no lag. Clicking pops straight to that ancestor.
 function PeekStrip({
   depth,
-  total,
+  gap,
   direction,
   zIndex,
   opacity,
@@ -75,7 +75,7 @@ function PeekStrip({
   onClick,
 }: {
   depth: number
-  total: number
+  gap: number
   direction: Direction
   zIndex: number
   opacity: number
@@ -104,9 +104,8 @@ function PeekStrip({
   // The stack slides out to make room as it grows (and back in as it shrinks): each
   // panel eases from flush with the sheet edge (offset 0) out to `depth · gap`, where
   // `gap` is one uniform per-level width for the whole stack (tighter the deeper the
-  // stack). A newly-stacked panel enters from under the sheet while the existing
-  // panels shift further out — and the reverse on close.
-  const gap = perLevelPeek(total, isLeft ? PEEK_DESKTOP : PEEK_MOBILE)
+  // stack — computed once by DrawerStack). A newly-stacked panel enters from under the
+  // sheet while the existing panels shift further out — and the reverse on close.
   const offset = isLeft ? { x: depth * gap } : { y: -depth * gap }
   const flush = isLeft ? { x: 0 } : { y: 0 }
 
@@ -256,6 +255,12 @@ export function DrawerStack() {
 
   // Map mode: stacked ancestor panels (portaled behind the drawer) + the single drawer.
   const target = overlayContainer()
+  // One uniform per-level peek width for the whole stack, tighter the deeper it goes —
+  // computed once here (it's a stack constant) rather than per strip.
+  const peekGap = perLevelPeek(
+    parentPaths.length,
+    direction === 'left' ? PEEK_DESKTOP : PEEK_MOBILE,
+  )
   // Always render the container + AnimatePresence (even at 0 ancestors) so a removed
   // strip animates out on the way back to the root instead of vanishing.
   const strips = (
@@ -269,9 +274,9 @@ export function DrawerStack() {
               key={path}
               depth={depth}
               direction={direction}
+              gap={peekGap}
               label={t('back')}
               opacity={Math.max(0.15, 0.55 - (depth - 1) * 0.18)}
-              total={parentPaths.length}
               zIndex={30 + i}
               onClick={() => navigate(path)}
             />

--- a/src/views/DrawerStack/DrawerStack.tsx
+++ b/src/views/DrawerStack/DrawerStack.tsx
@@ -278,6 +278,10 @@ export function DrawerStack() {
         open
         activeSnapPoint={direction === 'bottom' ? snap : undefined}
         direction={direction}
+        // The left panel (≥md) has no handle and no snap points, so restricting drag
+        // to the (absent) handle makes it undraggable — dismiss is the close button
+        // only. The mobile bottom sheet keeps its full-panel snap-drag.
+        handleOnly={direction === 'left'}
         setActiveSnapPoint={direction === 'bottom' ? setSnap : undefined}
         snapPoints={direction === 'bottom' ? SNAP_POINTS : undefined}
         onOpenChange={(o) => !o && control.dismiss()}

--- a/src/views/DrawerStack/DrawerStack.tsx
+++ b/src/views/DrawerStack/DrawerStack.tsx
@@ -21,16 +21,23 @@ import { ShareView } from '@/views/ShareView/ShareView'
 
 // Mobile bottom-sheet snap ladder (ascending; vaul reads a string as px, a number
 // as a fraction of the sheet height):
-//  - '96px'  peek — the handle + the search / title row
+//  - '80px'  peek — the handle + the search / title row
 //  - '300px' lower third — title + a list row + a peek of the next
 //  - 0.97    near-full
-const SNAP_POINTS = ['96px', '300px', 0.97]
-const PEEK_SNAP = '96px' // the collapsed peek
+const SNAP_POINTS = ['80px', '300px', 0.97]
+const PEEK_SNAP = '80px' // the collapsed peek
 const OPEN_SNAP = '300px' // default, and what the peek expands to
 
 // How far each stacked ancestor peeks out behind the active sheet.
 const PEEK_MOBILE = 5 // px above the sheet's top edge
 const PEEK_DESKTOP = 6 // px to the right of the left panel
+
+// Each deeper ancestor peeks a little LESS than the one before, so a tall stack
+// reads denser (and its total spread stays bounded) instead of fanning out
+// linearly. Cumulative offset at `depth` = base·(1−decay^depth)/(1−decay).
+const PEEK_DECAY = 0.6
+const peekOffset = (depth: number, base: number) =>
+  (base * (1 - Math.pow(PEEK_DECAY, depth))) / (1 - PEEK_DECAY)
 
 type Direction = 'left' | 'bottom'
 
@@ -97,7 +104,9 @@ function PeekStrip({
   // panel eases from flush with the sheet edge (offset 0) out to `depth * PEEK`, so
   // a newly-stacked panel enters from under the sheet while the existing panels shift
   // further out — and the reverse on close.
-  const offset = isLeft ? { x: depth * PEEK_DESKTOP } : { y: -depth * PEEK_MOBILE }
+  const offset = isLeft
+    ? { x: peekOffset(depth, PEEK_DESKTOP) }
+    : { y: -peekOffset(depth, PEEK_MOBILE) }
   const flush = isLeft ? { x: 0 } : { y: 0 }
 
   return (

--- a/src/views/DrawerStack/DrawerStack.tsx
+++ b/src/views/DrawerStack/DrawerStack.tsx
@@ -226,16 +226,19 @@ export function DrawerStack() {
             container={container}
             direction={direction}
             dismissible={parentPaths.length > 0}
+            // Same as the map drawer: the left panel (≥md) has no handle, so
+            // handle-only drag makes it undraggable — dismiss is the close button only.
+            handleOnly={direction === 'left'}
             onOpenChange={(o) => !o && control.dismiss()}
           >
             {sheet}
           </Drawer>
           {/* Map-less the drawer fills the container and its search header owns the
               top, so a top-left cog would cover the search field. Keep it on the left
-              but at the bottom, clear of the header; align="start" opens it upward.
-              z-50 so it sits above the fill-the-container drawer content (z-40, and
-              portaled in last) — otherwise a list row intercepts the cog's clicks. */}
-          <SettingsMenu className="absolute bottom-3 left-3 z-50" />
+              but at the bottom, clear of the header; side="top" opens the menu upward
+              from there. z-50 so it sits above the fill-the-container drawer content
+              (z-40, and portaled in last) — otherwise a list row intercepts its clicks. */}
+          <SettingsMenu className="absolute bottom-3 left-3 z-50" side="top" />
         </div>
       </DrawerControlContext.Provider>
     )

--- a/src/views/DrawerStack/DrawerStack.tsx
+++ b/src/views/DrawerStack/DrawerStack.tsx
@@ -32,12 +32,11 @@ const OPEN_SNAP = '300px' // default, and what the peek expands to
 const PEEK_MOBILE = 5 // px above the sheet's top edge
 const PEEK_DESKTOP = 6 // px to the right of the left panel
 
-// Each deeper ancestor peeks a little LESS than the one before, so a tall stack
-// reads denser (and its total spread stays bounded) instead of fanning out
-// linearly. Cumulative offset at `depth` = base·(1−decay^depth)/(1−decay).
-const PEEK_DECAY = 0.6
-const peekOffset = (depth: number, base: number) =>
-  (base * (1 - Math.pow(PEEK_DECAY, depth))) / (1 - PEEK_DECAY)
+// One uniform peek width per stack: every ancestor shares the same gap, and that gap
+// shrinks as the TOTAL depth grows — so each level stays evenly spaced while a taller
+// stack reads denser. `base` is the single-ancestor gap; strip d sits at `d · gap`.
+const PEEK_DECAY = 0.7
+const perLevelPeek = (total: number, base: number) => base * Math.pow(PEEK_DECAY, total - 1)
 
 type Direction = 'left' | 'bottom'
 
@@ -68,6 +67,7 @@ function TopView({ entry, parentPath }: { entry: StackEntry | null; parentPath: 
 // with no lag. Clicking pops straight to that ancestor.
 function PeekStrip({
   depth,
+  total,
   direction,
   zIndex,
   opacity,
@@ -75,6 +75,7 @@ function PeekStrip({
   onClick,
 }: {
   depth: number
+  total: number
   direction: Direction
   zIndex: number
   opacity: number
@@ -101,12 +102,12 @@ function PeekStrip({
   }
 
   // The stack slides out to make room as it grows (and back in as it shrinks): each
-  // panel eases from flush with the sheet edge (offset 0) out to `depth * PEEK`, so
-  // a newly-stacked panel enters from under the sheet while the existing panels shift
-  // further out — and the reverse on close.
-  const offset = isLeft
-    ? { x: peekOffset(depth, PEEK_DESKTOP) }
-    : { y: -peekOffset(depth, PEEK_MOBILE) }
+  // panel eases from flush with the sheet edge (offset 0) out to `depth · gap`, where
+  // `gap` is one uniform per-level width for the whole stack (tighter the deeper the
+  // stack). A newly-stacked panel enters from under the sheet while the existing
+  // panels shift further out — and the reverse on close.
+  const gap = perLevelPeek(total, isLeft ? PEEK_DESKTOP : PEEK_MOBILE)
+  const offset = isLeft ? { x: depth * gap } : { y: -depth * gap }
   const flush = isLeft ? { x: 0 } : { y: 0 }
 
   return (
@@ -270,6 +271,7 @@ export function DrawerStack() {
               direction={direction}
               label={t('back')}
               opacity={Math.max(0.15, 0.55 - (depth - 1) * 0.18)}
+              total={parentPaths.length}
               zIndex={30 + i}
               onClick={() => navigate(path)}
             />

--- a/src/views/DrawerStack/DrawerStack.tsx
+++ b/src/views/DrawerStack/DrawerStack.tsx
@@ -230,7 +230,12 @@ export function DrawerStack() {
           >
             {sheet}
           </Drawer>
-          <SettingsMenu className="absolute bottom-3 right-3 z-40" />
+          {/* Map-less the drawer fills the container and its search header owns the
+              top, so a top-left cog would cover the search field. Keep it on the left
+              but at the bottom, clear of the header; align="start" opens it upward.
+              z-50 so it sits above the fill-the-container drawer content (z-40, and
+              portaled in last) — otherwise a list row intercepts the cog's clicks. */}
+          <SettingsMenu className="absolute bottom-3 left-3 z-50" />
         </div>
       </DrawerControlContext.Provider>
     )
@@ -268,7 +273,10 @@ export function DrawerStack() {
         createPortal(
           <>
             {strips}
-            <SettingsMenu className="fixed right-3 top-16 z-40" />
+            {/* Top-left, offset past the left drawer on ≥md (flush left-0 on tablet,
+                floating to left-4 at ≥lg) so it never overlaps the panel. On mobile
+                the sheet is at the bottom, so the top-left corner is clear. */}
+            <SettingsMenu className="fixed left-3 top-3 z-40 md:left-[calc(var(--sy-drawer-w,22rem)+0.75rem)] lg:left-[calc(var(--sy-drawer-w,22rem)+1.75rem)]" />
           </>,
           target,
         )}

--- a/src/views/RegionView/RegionView.tsx
+++ b/src/views/RegionView/RegionView.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
 
@@ -27,13 +26,6 @@ export function RegionView({ slug }: { slug: string }) {
 
   useFrameOnTop(() => frameRegion(region), [region, frameRegion])
 
-  // Show the busiest child regions first (most events at the top). Copy before
-  // sorting so the query cache isn't mutated; equal counts keep the API order.
-  const subregions = useMemo(
-    () => [...region.subregions].sort((a, b) => b.eventCount - a.eventCount),
-    [region.subregions],
-  )
-
   const header = (region.countryCode && regionNames.of(region.countryCode)) || region.name
   const subheader = region.level === 'city' ? (region.subtitle ?? undefined) : undefined
   const canonicalUrl = validateWebUrl(region.webUrl)
@@ -55,7 +47,7 @@ export function RegionView({ slug }: { slug: string }) {
       </DrawerHeader>
       <DrawerBody>
         <List>
-          {subregions.map((child) => (
+          {region.subregions.map((child) => (
             <RegionCard
               key={child.id}
               count={child.eventCount}

--- a/src/views/RegionView/RegionView.tsx
+++ b/src/views/RegionView/RegionView.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
 
@@ -26,6 +27,13 @@ export function RegionView({ slug }: { slug: string }) {
 
   useFrameOnTop(() => frameRegion(region), [region, frameRegion])
 
+  // Show the busiest child regions first (most events at the top). Copy before
+  // sorting so the query cache isn't mutated; equal counts keep the API order.
+  const subregions = useMemo(
+    () => [...region.subregions].sort((a, b) => b.eventCount - a.eventCount),
+    [region.subregions],
+  )
+
   const header = (region.countryCode && regionNames.of(region.countryCode)) || region.name
   const subheader = region.level === 'city' ? (region.subtitle ?? undefined) : undefined
   const canonicalUrl = validateWebUrl(region.webUrl)
@@ -47,7 +55,7 @@ export function RegionView({ slug }: { slug: string }) {
       </DrawerHeader>
       <DrawerBody>
         <List>
-          {region.subregions.map((child) => (
+          {subregions.map((child) => (
             <RegionCard
               key={child.id}
               count={child.eventCount}


### PR DESCRIPTION
## Summary

Follow-up fixes and polish for the nested-drawer navigation shell (#31 / feat #30), plus a second round of Adjust-phase tweaks. Each is its own commit.

**Original batch (#35):**
- **Drag:** the desktop (≥md) left panel is undraggable (vaul `handleOnly`); dismissal is the close button only, so a drag no longer desyncs the shadow or dismisses the drawer. Applied to both map and map-less drawers.
- **Spacing:** balanced handle→header gap on the mobile bottom sheet.
- **Flags:** country flags shrink below `lg` (mobile + tablet), restoring at desktop.
- **Cog:** the settings cog moves to the top-left, offset clear of the drawer on ≥md; menu opens from the left (`align="start"`). Map-less keeps it bottom-left (`side="top"`).
- **i18n:** every `useLocale` consumer relocalizes together on a language change (`useSyncExternalStore` on `languageChanged`).
- **Theme:** the widget renders the built-in teal/orange default when no real brand palette resolves — achromatic seeds (the backend `#000000` sentinel) are treated as unset.
- **DetailRow:** the leading icon box is an explicit, always-square discriminated `box` prop.

**Adjust follow-ups:**
- **Language switching:** `Widget.tsx` re-applied the embed's `locale` prop in the render body on every render, clobbering a language the user picked from the menu — removed (App's mount effect already applies the initial locale).
- **Ordering:** country and region lists are ordered by event count, busiest first — done in the fetchers (`getCountries`/`getRegion`), next to the `eventCount>0` filters they already do.
- **Stacking peek:** one uniform per-level gap for the whole stack that tightens with total depth (`base·0.7^(total−1)`) — every level evenly spaced, deeper stacks denser.
- **Polish:** smaller collapsed snap point; smaller event description text; drawer text selectable on desktop; smaller settings cog.
- **Tailwind:** swapped arbitrary classes for built-ins where exact (`text-[24px]→text-2xl`, `min-w-[11rem]→min-w-44`, `h-[100dvh]→h-dvh`).

## Changes

- `src/config/api/fetch.ts` — busiest-first ordering moved into `getCountries`/`getRegion` via a shared `byEventCountDesc` comparator (data-layer concern, matching `getEvents`); the views just render the pre-sorted data.
- `src/Widget.tsx` — dropped the render-body `i18n.changeLanguage`.
- `src/hooks/use-locale.ts` — `useState` → `useSyncExternalStore(languageChanged)`.
- `src/config/theme/palette.ts` — `isBrandSeed` rejects achromatic seeds so primary/secondary fall back to the globals.css default.
- `src/components/molecules/DetailRow/DetailRow.tsx` — freeform `children` → structured `box`.

## Verification

- Lint: ✓ (`pnpm lint`)
- Types: ✓ (`pnpm typecheck`)
- Tests: ✓ Unit lane green — 131 tests, incl. DetailRow SSR + palette achromatic-seed regression tests
- Build: CI runs `pnpm build` + `ladle:build`

## Manual / visual verification

Driven in the running widget (Playwright, standalone dev against the local backend):

- **Ordering:** countries → Brazil (80), United Kingdom (61), Australia (49)… (monotonic desc); a region (UK) → South East (30) … Wales (1). Confirmed after moving the sort into the fetchers.
- **Language:** English→Français relocalizes the country list in place, no navigation; `localStorage` persists.
- **Theme:** computed `--primary-9` = `176 23% 60%` (teal), no inline override — the `#000000` client seeds fall back to the default.
- **Drag:** a left-drag on the ≥md panel leaves it at `transform: none`, not dismissed.
- **Cog / flags / DetailRow / peek:** cog clears the drawer by 12px at md/lg (32×32 after shrink); flags 28/36px; three 44×44 square DetailRow boxes; peek gaps uniform per stack (2 levels → 4.2px, 4 levels → 2.06px) and denser when deeper; desktop drawer `user-select: text`.

## Notes for reviewer

- **Simplify + code review + security review** (dispatched subagents, one high-effort code-review pass) all ran over the Adjust diff. The simplify pass moved the event-count ordering into the data layer (removing two view-level `useMemo` sorts + a redundant filter). Code review found **no correctness bugs**; security review found **no risk** (the fetcher `.sort()` mutates only freshly-built arrays — not the React Query cache — and the Widget change doesn't touch the auth/host-prop boundary). No findings dismissed.
- **Language regression:** standalone switching was already working; the fix targets the embedded widget path (the render-body clobber). Worth a confirm in an embedded `pnpm preview` build.
- **Map-less cog** is bottom-left (not top-left): map-less has no map, so the drawer fills the container and its search header owns the top — bottom-left keeps the cog clear and usable.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
