### PR TITLE
docs(config): i18n/eslint gotchas + i18n locale-key helper

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -23,7 +23,11 @@ a file manually.
 - ESLint enforces `import/order` with blank lines between groups
   (type → builtin → object → external → internal → parent → sibling → index).
   The auto-fix handles ordering; don't fight it.
-- `unused-imports/no-unused-imports` auto-removes dead imports on fix.
+- `unused-imports/no-unused-imports` auto-removes dead imports on fix — and the
+  PostToolUse hook runs that fix after **every** edit. So an import added in a
+  separate edit from its first use is stripped before the use lands, then fails
+  typecheck with "Cannot find name". Add the import **and** its usage in the same
+  edit (or add the usage first), never import-first-in-its-own-edit.
 
 ## Naming
 

--- a/.claude/rules/i18n-and-state.md
+++ b/.claude/rules/i18n-and-state.md
@@ -18,6 +18,14 @@ alwaysApply: false
 - **Interpolation uses Ruby-style delimiters** `%{var}` (prefix `%{`, suffix `}`),
   not the i18next default `{{var}}` — these JSON files are shared with a Rails
   backend. Match that syntax in both code and locale files.
+- **`count` is a reserved plural trigger — don't use it for a plain number.**
+  Passing an option named `count` to `t()` activates i18next pluralization: it
+  resolves `key_one` / `key_other` (not the base key), and with `debug: true`
+  logs a missing-key warning when those forms don't exist. For a non-plural
+  interpolated number (e.g. a result count in a button), name the variable
+  anything else — `t('x', { total })` with `%{total}` — or build the string in
+  code. Only pass `count` when the key genuinely has `_one`/`_other` forms (see
+  `locations.description_one` / `venues.description_one`).
 - Locale is detected from the `locale` query param (`lookupQuerystring: 'locale'`)
   and can be overridden by the widget's `locale` prop or the client's
   `client.locale` (see `App.tsx`). Read the active locale with `useLocale()`,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ladle": "ladle serve",
     "ladle:build": "ladle build",
     "preview": "vite preview",
+    "i18n:add": "node scripts/add-locale-key.mjs",
     "types:cms": "mkdir -p src/types/payload && curl -fsSL -o src/types/payload/payload-types.ts https://raw.githubusercontent.com/sydevs/SahajCloud/refs/heads/main/src/payload-types.ts && curl -fsSL -o src/types/payload/response-types.ts https://raw.githubusercontent.com/sydevs/SahajCloud/refs/heads/main/src/collections/Events/endpoints/responseTypes.ts && node scripts/strip-payload-augmentation.mjs",
     "types:openapi": "node scripts/fetch-openapi.mjs"
   },

--- a/scripts/add-locale-key.mjs
+++ b/scripts/add-locale-key.mjs
@@ -1,0 +1,78 @@
+/**
+ * Adds (or overwrites) one i18n key across the hand-maintained locale JSON under
+ * public/locales/<lng>/<ns>.json, keeping the files prettier-formatted (2-space,
+ * trailing newline) and reporting which locales were left to fall back to `en`.
+ *
+ * Usage:
+ *   node scripts/add-locale-key.mjs <dotted.key> '<{lng:value}>' [namespace]
+ *   pnpm i18n:add <dotted.key> '<{lng:value}>' [namespace]
+ *
+ * Example:
+ *   pnpm i18n:add filters.nearby '{"en":"< %{km} km","fr":"< %{km} km"}'
+ *
+ * The values map is { <lng>: <value> }; `en` (the fallbackLng) is required.
+ * Locales present in public/locales but absent from the map are left untouched
+ * (they fall back to en) and listed. Interpolation uses this repo's Ruby-style
+ * `%{var}` — and remember `count` triggers i18next pluralization, so use a
+ * different variable name for a plain number (see .claude/rules/i18n-and-state.md).
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const LOCALES_DIR = fileURLToPath(new URL('../public/locales', import.meta.url))
+
+const [, , key, valuesJson, ns = 'common'] = process.argv
+
+if (!key || !valuesJson) {
+  console.error("Usage: node scripts/add-locale-key.mjs <dotted.key> '<{lng:value}>' [namespace]")
+  process.exit(1)
+}
+
+let values
+try {
+  values = JSON.parse(valuesJson)
+} catch {
+  console.error('The values argument must be a JSON object, e.g. \'{"en":"…","fr":"…"}\'.')
+  process.exit(1)
+}
+
+if (!values.en) {
+  console.error('`en` is the fallback language and must be provided.')
+  process.exit(1)
+}
+
+const segments = key.split('.')
+
+const setNested = (obj, value) => {
+  let node = obj
+
+  for (const segment of segments.slice(0, -1)) {
+    if (typeof node[segment] !== 'object' || node[segment] === null) node[segment] = {}
+    node = node[segment]
+  }
+
+  node[segments.at(-1)] = value
+}
+
+const locales = readdirSync(LOCALES_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+
+const updated = []
+
+for (const lng of locales) {
+  if (!(lng in values)) continue
+
+  const file = `${LOCALES_DIR}/${lng}/${ns}.json`
+  const json = JSON.parse(readFileSync(file, 'utf8'))
+
+  setNested(json, values[lng])
+  writeFileSync(file, `${JSON.stringify(json, null, 2)}\n`)
+  updated.push(lng)
+}
+
+const skipped = locales.filter((lng) => !(lng in values))
+
+console.log(`Set ${ns}:${key} in ${updated.length} locale(s): ${updated.join(', ')}`)
+if (skipped.length > 0)
+  console.log(`Left to fall back to en (no value provided): ${skipped.join(', ')}`)


### PR DESCRIPTION
## Summary

Config/docs improvements captured from a `/reflect-session` pass on the
event-filters build (#39) — no product code changes.

- **`.claude/rules/i18n-and-state.md`** — document that passing a `count` option to
  `t()` triggers i18next pluralization (resolves `key_one`/`key_other`, logs a
  missing-key warning under `debug: true`); use a different variable name for a
  plain interpolated number.
- **`.claude/rules/code-style.md`** — note that the PostToolUse `eslint --fix`
  strips an import added in a separate edit from its first use; add the import and
  its usage in the same edit.
- **`scripts/add-locale-key.mjs`** (+ `pnpm i18n:add`) — set one i18n key across all
  `public/locales/<lng>/<ns>.json`, prettier-formatted, reporting which locales are
  left to fall back to `en`. Replaces the throwaway node scripts used repeatedly
  during #39.

## Verification

- The script is functionally verified (usage guard, nested-key creation,
  2-space/trailing-newline output matching prettier, fall-back reporting); the test
  key was reverted.
- Docs-only + a dev-only script — no runtime/bundle impact. CI runs lint + typecheck
  + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
