### PR TITLE
feat(search): surface online classes and make filters URL-linkable

### DIFF
--- a/.claude/rules/i18n-and-state.md
+++ b/.claude/rules/i18n-and-state.md
@@ -3,6 +3,7 @@ description: i18next localization and zustand state-store conventions.
 globs:
   - "src/config/i18n.ts"
   - "src/config/store.ts"
+  - "src/hooks/use-filters.ts"
   - "src/hooks/use-locale.ts"
   - "public/locales/**"
 alwaysApply: false
@@ -34,23 +35,36 @@ alwaysApply: false
   `supportedLanguages` in `i18n.ts`, and check `MAP_WORLDVIEWS` in
   `src/components/mapbox/map.tsx` for whether a worldview is needed.
 - Locale JSON under `public/locales/` is hand-maintained — keep keys in sync
-  across languages; `en` is the `fallbackLng`.
+  across languages; `en` is the `fallbackLng`. Add a key across every locale with
+  `pnpm i18n:add <dotted.key> '<{lng:value}>' [ns]` (`scripts/add-locale-key.mjs`).
+- **A new locale key needs a full page reload in dev**, not just HMR: HMR reloads
+  the component but not i18next's already-fetched in-memory translations, so the key
+  renders as its raw name (e.g. `online_classes`) until you reload. A raw key showing
+  right after `pnpm i18n:add` is almost always this, **not** a missing/mis-namespaced key.
 
 ## zustand stores (`src/config/store.ts`)
 
-Three stores, each the single source of truth for its slice:
+Two stores, each the single source of truth for its slice:
 
 - **`useViewState`** — map camera (`zoom/latitude/longitude`), current
   `selection`, and `boundary`. The map's hot path reads it via a `useShallow`
   selector — keep that pattern when consuming multiple fields so components only
   re-render on the fields they use.
-- **`useSearchState`** — search filters (`onlineOnly`).
 - **`useRegistrationDraft`** — in-progress RegistrationView form values, hoisted
   out of the form so the md-crossing drawer remount can't drop a half-filled form.
 
-Navigation is **not** a store: the drawer stack is a pure function of the URL
-(`resolveStack` in `src/lib/shape/path.ts`); dismissing a drawer is
-`navigate(parentPath)`. Camera control goes through the `MapController` seam
+Two slices are **URL-derived, not stores** — the URL query is their single source
+of truth, so both are linkable/shareable:
+
+- **Search filters** — read with `useEventFilters`, mutate with `useSetFilters`
+  (`src/hooks/use-filters.ts`); serialized by `filtersToParams` / `filtersFromParams`
+  (`src/lib/shape/filters.ts`). The map, the results list, the active-filter pills,
+  and the FilterButton badge all read the same URL. (There is no `useSearchState`
+  store — filters used to live in zustand.)
+- **Navigation** — the drawer stack is a pure function of the URL (`resolveStack`
+  in `src/lib/shape/path.ts`); dismissing a drawer is `navigate(parentPath)`.
+
+Camera control goes through the `MapController` seam
 (`src/hooks/use-map-controller.tsx`), never a store or the map directly.
 
 Conventions:

--- a/.claude/skills/finalize-pr/SKILL.md
+++ b/.claude/skills/finalize-pr/SKILL.md
@@ -122,12 +122,17 @@ BODY_FILE=$(mktemp -t pr-body.XXXXXX).md
   ```bash
   gh pr create --title "<conventional commit title>" --body-file "$BODY_FILE" --base main
   ```
-- **PR exists** → **refresh** its description so it reflects the final diff + verification
-  (Adjust-phase commits may have changed the story since it was opened):
+- **PR exists** → **refresh** its **title and description** so they reflect the final diff +
+  verification, not the state when it was first opened. Re-derive both from the **current**
+  `origin/main...HEAD` — Adjust-phase commits since the last push often change the story (a
+  scope shift, a reverted or newly-added sub-feature, fresh verification), so don't reuse the
+  originals:
   ```bash
-  gh pr edit <pr> --body-file "$BODY_FILE"
+  gh pr edit <pr> --title "<conventional commit title, re-derived>" --body-file "$BODY_FILE"
   ```
-  Never leave a stale description from an earlier state.
+  Update the title whenever the branch no longer matches it (a feature dropped or added since
+  the last push); keep it only if it's still accurate. Never leave a stale title or description
+  from an earlier state.
 
 ### 7. Watch CI and fix (capped)
 
@@ -166,7 +171,7 @@ test:run + build + ladle:build); the **Smoke** job runs separately against the C
   subagent**, never inline in the main thread.
 - **One** code-review pass — no redundant second review.
 - **Always** use `--body-file` (a `mktemp` path) for `gh pr create` / `gh pr edit`; always refresh a
-  stale PR body.
+  stale PR **title and** body to match the current `origin/main...HEAD`.
 - **Cap** the CI fix-loop at 3 iterations, then hand back to the user.
 
 ## References

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ event hierarchy.
 | Map            | **Mapbox GL** via `react-map-gl`, `@mapbox/search-js-react`, `@turf/*` geo helpers |
 | Routing        | `react-router` v7, **HashRouter** (basename `!`) — the widget owns the URL hash |
 | Data           | **TanStack Query** + `axios` (`src/config/api/`), **zod**-validated responses |
-| State          | **zustand** stores (`src/config/store.ts`) |
+| State          | **zustand** (`src/config/store.ts`) + URL query (search filters) |
 | i18n           | `i18next` + `react-i18next`, HTTP backend loads `public/locales/<lng>/<ns>.json` |
 | Forms          | `react-hook-form` + `zod` (`@hookform/resolvers`) |
 | Misc           | `framer-motion`, `swiper`, `luxon` (dates), `dompurify`, `fathom-client` (analytics), `react-helmet-async` |
@@ -91,7 +91,7 @@ src/
   views/              # URL-driven drawer views (replace pages/): DrawerStack + Root/Search/Region/Event/Registration/Share
   config/
     api/              # axios client + zod-parsed fetchers (fetch.ts, mutate.ts, auth.ts)
-    store.ts          # zustand stores (view / search / registration-draft)
+    store.ts          # zustand stores (view / registration-draft; filters live in the URL)
     mode.ts           # WidgetMode context (standalone + hasMap)
     i18n.ts           # i18next init
     site.ts, responsive.ts
@@ -107,9 +107,10 @@ public/locales/<lng>/ # translation JSON (en, fr, … hand-maintained)
 - **API layer**: every fetcher in `src/config/api/fetch.ts` parses the response
   through a zod schema from `src/types/`. Keep that contract — see
   `.claude/rules/data-layer.md`.
-- **State**: zustand stores are the single source of truth for map view and
-  search filters. Read with `useShallow` selectors in hot paths (the map). See
-  `.claude/rules/i18n-and-state.md`.
+- **State**: zustand stores (`src/config/store.ts`) are the single source of truth
+  for the map view + registration draft; **search filters live in the URL query**
+  (`useEventFilters`/`useSetFilters` in `src/hooks/use-filters.ts`). Read stores with
+  `useShallow` selectors in hot paths (the map). See `.claude/rules/i18n-and-state.md`.
 - **Navigation**: the UI is a **URL-driven drawer stack** (`src/views/`).
   `resolveStack` (`src/lib/shape/path.ts`) turns the pathname into the open
   drawers; `DrawerStack` renders RootView (base) + one nested vaul drawer per

--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Žádné události do %{km} km."
   },
-  "search_placeholder": "Hledat události poblíž…"
+  "search_placeholder": "Hledat události poblíž…",
+  "online_classes": "Online kurzy"
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Keine Veranstaltungen innerhalb von %{km} km."
   },
-  "search_placeholder": "Veranstaltungen suchen in …"
+  "search_placeholder": "Veranstaltungen suchen in …",
+  "online_classes": "Online-Kurse"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -67,5 +67,6 @@
     "description_other": "%{count} free meditation classes at %{venue}",
     "title": "Free Meditation Classes at %{venue}"
   },
-  "search_placeholder": "Search for events near…"
+  "search_placeholder": "Search for events near…",
+  "online_classes": "Online Classes"
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Ningún evento en un radio de %{km} km."
   },
-  "search_placeholder": "Buscar eventos cerca de…"
+  "search_placeholder": "Buscar eventos cerca de…",
+  "online_classes": "Clases en línea"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Aucun événement dans un rayon de %{km} km."
   },
-  "search_placeholder": "Rechercher des événements près de…"
+  "search_placeholder": "Rechercher des événements près de…",
+  "online_classes": "Cours en ligne"
 }

--- a/public/locales/hu/common.json
+++ b/public/locales/hu/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Nincs esemény %{km} km-en belül."
   },
-  "search_placeholder": "Események keresése a közelben…"
+  "search_placeholder": "Események keresése a közelben…",
+  "online_classes": "Online órák"
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Geen evenementen binnen %{km} km."
   },
-  "search_placeholder": "Zoek evenementen in de buurt van…"
+  "search_placeholder": "Zoek evenementen in de buurt van…",
+  "online_classes": "Online lessen"
 }

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Nenhum evento num raio de %{km} km."
   },
-  "search_placeholder": "Buscar eventos perto de…"
+  "search_placeholder": "Buscar eventos perto de…",
+  "online_classes": "Aulas on-line"
 }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Нет событий в радиусе %{km} км."
   },
-  "search_placeholder": "Искать события рядом с…"
+  "search_placeholder": "Искать события рядом с…",
+  "online_classes": "Онлайн-занятия"
 }

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -53,5 +53,6 @@
     "nearby": "< %{km} km",
     "no_nearby": "Немає подій у радіусі %{km} км."
   },
-  "search_placeholder": "Шукати події поблизу…"
+  "search_placeholder": "Шукати події поблизу…",
+  "online_classes": "Онлайн-заняття"
 }

--- a/scripts/add-locale-key.mjs
+++ b/scripts/add-locale-key.mjs
@@ -51,7 +51,7 @@ const setNested = (obj, value) => {
     node = node[segment]
   }
 
-  node[segments.at(-1)] = value
+  node[segments[segments.length - 1]] = value
 }
 
 const locales = readdirSync(LOCALES_DIR, { withFileTypes: true })

--- a/src/components/molecules/ActiveFilterPills/ActiveFilterPills.stories.tsx
+++ b/src/components/molecules/ActiveFilterPills/ActiveFilterPills.stories.tsx
@@ -6,7 +6,7 @@ import { StoryWrapper, StorySection } from '../../ladle'
 
 import { ActiveFilterPills } from './ActiveFilterPills'
 
-import { DEFAULT_FILTERS, filtersToParams } from '@/lib/shape'
+import { filtersToParams } from '@/lib/shape'
 
 export default {
   title: 'Molecules',
@@ -15,7 +15,6 @@ export default {
 // A mix of active filters, seeded into the URL query — the filters' source of truth,
 // which the pills read via useEventFilters. A local MemoryRouter carries it.
 const seededSearch = `/search?${filtersToParams({
-  ...DEFAULT_FILTERS,
   format: 'online',
   cadence: 'WEEKLY',
   daysOfWeek: [1, 3, 5],

--- a/src/components/molecules/ActiveFilterPills/ActiveFilterPills.stories.tsx
+++ b/src/components/molecules/ActiveFilterPills/ActiveFilterPills.stories.tsx
@@ -1,35 +1,31 @@
 import type { Story, StoryDefault } from '@ladle/react'
 
-import { useEffect } from 'react'
+import { MemoryRouter } from 'react-router'
 
 import { StoryWrapper, StorySection } from '../../ladle'
 
 import { ActiveFilterPills } from './ActiveFilterPills'
 
-import { useSearchState } from '@/config/store'
-import { DEFAULT_FILTERS } from '@/lib/shape'
+import { DEFAULT_FILTERS, filtersToParams } from '@/lib/shape'
 
 export default {
   title: 'Molecules',
 } satisfies StoryDefault
 
+// A mix of active filters, seeded into the URL query — the filters' source of truth,
+// which the pills read via useEventFilters. A local MemoryRouter carries it.
+const seededSearch = `/search?${filtersToParams({
+  ...DEFAULT_FILTERS,
+  format: 'online',
+  cadence: 'WEEKLY',
+  daysOfWeek: [1, 3, 5],
+  timeOfDay: [9, 17],
+  languages: ['en', 'fr'],
+}).toString()}`
+
 /** ActiveFilterPills — the applied filters as removable pills (one per filter type). */
-export const ActiveFilterPillsStory: Story = () => {
-  // Seed the shared filter store with a mix of active filters; reset on unmount.
-  useEffect(() => {
-    useSearchState.setState({
-      ...DEFAULT_FILTERS,
-      format: 'online',
-      cadence: 'WEEKLY',
-      daysOfWeek: [1, 3, 5],
-      timeOfDay: [9, 17],
-      languages: ['en', 'fr'],
-    })
-
-    return () => useSearchState.setState({ ...DEFAULT_FILTERS })
-  }, [])
-
-  return (
+export const ActiveFilterPillsStory: Story = () => (
+  <MemoryRouter initialEntries={[seededSearch]}>
     <StoryWrapper>
       <StorySection
         description="The applied filters as removable pills — the day-of-week and language selections each collapse into one pill. The optional distance cap (search-only) leads the row."
@@ -40,7 +36,7 @@ export const ActiveFilterPillsStory: Story = () => {
 
       <div />
     </StoryWrapper>
-  )
-}
+  </MemoryRouter>
+)
 
 ActiveFilterPillsStory.storyName = 'ActiveFilterPills'

--- a/src/components/molecules/ActiveFilterPills/ActiveFilterPills.tsx
+++ b/src/components/molecules/ActiveFilterPills/ActiveFilterPills.tsx
@@ -3,7 +3,7 @@ import { Info } from 'luxon'
 import { useTranslation } from 'react-i18next'
 
 import { Chip } from '@/components/atoms/Chip'
-import { useSearchState } from '@/config/store'
+import { useEventFilters, useSetFilters } from '@/hooks/use-filters'
 import { useLocale } from '@/hooks/use-locale'
 import { formatHour } from '@/lib'
 import { TIME_MAX, TIME_MIN, isTimeRestricted } from '@/lib/shape'
@@ -26,18 +26,8 @@ export type ActiveFilterPillsProps = {
 export function ActiveFilterPills({ nearby }: ActiveFilterPillsProps) {
   const { t } = useTranslation('common')
   const { locale, languageLabel } = useLocale()
-  const {
-    format,
-    timeOfDay,
-    daysOfWeek,
-    languages,
-    cadence,
-    setFormat,
-    setCadence,
-    setTimeOfDay,
-    setDaysOfWeek,
-    setLanguages,
-  } = useSearchState()
+  const { format, timeOfDay, daysOfWeek, languages, cadence } = useEventFilters()
+  const { setFormat, setCadence, setTimeOfDay, setDaysOfWeek, setLanguages } = useSetFilters()
 
   const weekdaysShort = useMemo(() => Info.weekdays('short', { locale }), [locale])
 

--- a/src/components/molecules/OnlineClassesCard/OnlineClassesCard.stories.tsx
+++ b/src/components/molecules/OnlineClassesCard/OnlineClassesCard.stories.tsx
@@ -1,0 +1,29 @@
+import type { Story, StoryDefault } from '@ladle/react'
+
+import { StoryWrapper, StorySection } from '../../ladle'
+
+import { OnlineClassesCard } from './OnlineClassesCard'
+
+import { List } from '@/components/molecules/List'
+
+export default { title: 'Molecules / List' } satisfies StoryDefault
+
+/**
+ * OnlineClassesCard — the shared entry into online classes (MonitorIcon + count),
+ * used atop a region view and the country list. Only `count`/`href` vary.
+ */
+export const Default: Story = () => (
+  <StoryWrapper>
+    <StorySection inContext={true} title="Online Classes card">
+      <div className="max-w-md rounded-lg border border-divider overflow-hidden">
+        <List>
+          <OnlineClassesCard count={28} href="#online" />
+        </List>
+      </div>
+    </StorySection>
+
+    <div />
+  </StoryWrapper>
+)
+
+Default.storyName = 'Online Classes Card'

--- a/src/components/molecules/OnlineClassesCard/OnlineClassesCard.tsx
+++ b/src/components/molecules/OnlineClassesCard/OnlineClassesCard.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from 'react-i18next'
+
+import { MonitorIcon } from '@/components/atoms/Icons'
+import { RegionCard } from '@/components/molecules/RegionCard'
+
+export interface OnlineClassesCardProps {
+  count: number
+  href: string
+}
+
+// A list entry into online classes — placeless events that belong to no region.
+// Rendered on a region view (→ the `<region>/online` roll-up drawer) and on the
+// country list (→ the online-filtered search); only `count`/`href` differ, so the
+// icon + label stay in one place.
+export function OnlineClassesCard({ count, href }: OnlineClassesCardProps) {
+  const { t } = useTranslation('common')
+
+  return (
+    <RegionCard count={count} href={href} label={t('online_classes')}>
+      <MonitorIcon className="mr-3 shrink-0 text-2xl" />
+    </RegionCard>
+  )
+}

--- a/src/components/molecules/OnlineClassesCard/index.ts
+++ b/src/components/molecules/OnlineClassesCard/index.ts
@@ -1,0 +1,2 @@
+export { OnlineClassesCard } from './OnlineClassesCard'
+export type { OnlineClassesCardProps } from './OnlineClassesCard'

--- a/src/components/molecules/RegionCard/RegionCard.tsx
+++ b/src/components/molecules/RegionCard/RegionCard.tsx
@@ -15,7 +15,7 @@ export function RegionCard({ label, subtitle, count, href, children }: RegionCar
       className="px-6 block text-inherit transition-colors hover:bg-primary-2 dark:hover:bg-gray-3"
       href={href}
     >
-      <li className="py-5 flex flex-row items-center font-semibold border-b border-divider">
+      <li className="py-4 flex flex-row items-center font-semibold border-b border-divider">
         {children}
         <div className="text-lg flex-grow">
           <div>{label}</div>

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -24,6 +24,8 @@ export { List } from './List'
 
 export { RegionCard } from './RegionCard'
 export type { RegionCardProps } from './RegionCard'
+export { OnlineClassesCard } from './OnlineClassesCard'
+export type { OnlineClassesCardProps } from './OnlineClassesCard'
 
 export { EventCard } from './EventCard'
 export type { EventCardProps } from './EventCard'

--- a/src/components/organisms/EventsList/EventsList.tsx
+++ b/src/components/organisms/EventsList/EventsList.tsx
@@ -9,7 +9,7 @@ import { Alert } from '@/components/atoms/Alert'
 import { isSoon } from '@/lib'
 import { EventSlim } from '@/types'
 import { filtersKey, hasActiveFilters, isOnline, nextOccurrence } from '@/lib/shape'
-import { useEventFilters, useSearchState } from '@/config/store'
+import { useEventFilters, useSetFilters } from '@/hooks/use-filters'
 import api from '@/config/api'
 import i18n from '@/config/i18n'
 
@@ -98,8 +98,8 @@ export function DynamicEventsList({
 // reason.
 function EmptyResults({ nearbyKm }: { nearbyKm?: number }) {
   const { t } = useTranslation('common')
-  const active = useSearchState((state) => hasActiveFilters(state))
-  const clearFilters = useSearchState((state) => state.clearFilters)
+  const active = hasActiveFilters(useEventFilters())
+  const { clearFilters } = useSetFilters()
 
   if (nearbyKm !== undefined) {
     return (

--- a/src/components/organisms/Mapbox/Map.tsx
+++ b/src/components/organisms/Mapbox/Map.tsx
@@ -18,7 +18,8 @@ import {
   boundsLayer,
 } from './layers'
 
-import { useEventFilters, useViewState } from '@/config/store'
+import { useViewState } from '@/config/store'
+import { useEventFilters } from '@/hooks/use-filters'
 import api from '@/config/api'
 import { GEOJSON_STALE_TIME } from '@/config/query-client'
 import { hasActiveFilters, matchesFilters, safePath } from '@/lib/shape'

--- a/src/components/organisms/Mapbox/MapSearch.tsx
+++ b/src/components/organisms/Mapbox/MapSearch.tsx
@@ -35,7 +35,19 @@ export function MapSearch({ onSelect }: SearchProps) {
       value={searchQuery}
       onChange={(query) => {
         setSearchQuery(query)
-        setSearchParams({ q: query })
+        // Merge `q` into the existing query so the active filters (and bbox/center)
+        // survive typing — they live only in the URL now. `replace` so per-keystroke
+        // edits don't stack history.
+        setSearchParams(
+          (prev) => {
+            const next = new URLSearchParams(prev)
+
+            next.set('q', query)
+
+            return next
+          },
+          { replace: true },
+        )
       }}
       onRetrieve={onSelect}
     />

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -137,7 +137,7 @@ describe('getRegion (unified hierarchy derivation)', () => {
   })
 
   // Belgium(28), a country with three city children: Antwerpen(473) [2 located →
-  // carded], Brussels(470) [1 located → promoted], Ghent(475) [1 online → no card].
+  // carded], Brussels(470) [1 located → carded], Ghent(475) [1 online → no card].
   const country = {
     id: 28,
     slug: 'belgium',

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -100,94 +100,187 @@ describe('getGeojson', () => {
 })
 
 describe('getRegion (unified hierarchy derivation)', () => {
-  // Belgium(28) → Brussels(470), with one located event under Brussels. The
-  // region read resolves by slug alone; the country's path + its child's nested
-  // path come from the server `webPath`; counts/bounds from the feed's breadcrumb ids.
-  const route = (
-    url: string,
-    config?: { params?: { where?: Record<string, { equals?: unknown }> } },
-  ) => {
+  // One geojson feature; `region` carries the breadcrumb ancestry the split reads,
+  // geometry is null for online events, `next` seeds the roll-up ordering.
+  const feature = ({
+    id,
+    regionId,
+    slug,
+    breadcrumbs,
+    eventType = 'offline',
+    coordinates,
+    webPath,
+    next,
+  }: {
+    id: number
+    regionId: number
+    slug: string
+    breadcrumbs: number[]
+    eventType?: 'offline' | 'online'
+    coordinates?: [number, number]
+    webPath?: string
+    next?: string
+  }) => ({
+    type: 'Feature',
+    geometry: coordinates ? { type: 'Point', coordinates } : null,
+    properties: {
+      id,
+      title: `Event ${id}`,
+      eventType,
+      languages: ['nl'],
+      webPath,
+      region: {
+        id: regionId,
+        slug,
+        level: 'city',
+        breadcrumbs: breadcrumbs.map((doc) => ({ doc })),
+      },
+      schedule: next ? { firstDate: '2026-01-01T00:00:00Z', upcomingDates: [next] } : undefined,
+    },
+  })
+
+  // Belgium(28), a country with three city children: Antwerpen(473) [2 located →
+  // carded], Brussels(470) [1 located → promoted], Ghent(475) [1 online → no card].
+  const country = {
+    id: 28,
+    slug: 'belgium',
+    level: 'country',
+    name: 'Belgium',
+    webPath: '/belgium',
+    webUrl: 'https://atlas.example/belgium',
+    legacyData: { countryCode: 'BE' },
+  }
+  const children = [
+    { id: 473, slug: 'antwerpen', level: 'city', name: 'Antwerpen', webPath: '/belgium/antwerpen' },
+    { id: 470, slug: 'brussels', level: 'city', name: 'Brussels', webPath: '/belgium/brussels' },
+    { id: 475, slug: 'ghent', level: 'city', name: 'Ghent', webPath: '/belgium/ghent' },
+  ]
+  const countryFeed = [
+    feature({
+      id: 1,
+      regionId: 473,
+      slug: 'antwerpen',
+      breadcrumbs: [28, 473],
+      coordinates: [4.4, 51.2],
+    }),
+    feature({
+      id: 2,
+      regionId: 473,
+      slug: 'antwerpen',
+      breadcrumbs: [28, 473],
+      coordinates: [4.41, 51.21],
+    }),
+    feature({
+      id: 3,
+      regionId: 470,
+      slug: 'brussels',
+      breadcrumbs: [28, 470],
+      coordinates: [4.35, 50.85],
+    }),
+    feature({
+      id: 4,
+      regionId: 475,
+      slug: 'ghent',
+      breadcrumbs: [28, 475],
+      eventType: 'online',
+      next: '2026-08-01T00:00:00Z',
+    }),
+    feature({
+      id: 5,
+      regionId: 473,
+      slug: 'antwerpen',
+      breadcrumbs: [28, 473],
+      eventType: 'online',
+      next: '2026-07-20T00:00:00Z',
+    }),
+  ]
+
+  const countryRoute = (url: string, config?: { params?: { where?: Record<string, unknown> } }) => {
     const where = config?.params?.where
 
-    if (url === '/regions' && where?.slug) {
-      return {
-        data: {
-          docs: [
-            {
-              id: 28,
-              slug: 'belgium',
-              level: 'country',
-              name: 'Belgium',
-              webPath: '/belgium',
-              webUrl: 'https://atlas.example/belgium',
-              legacyData: { countryCode: 'BE' },
-            },
-          ],
-        },
-      }
-    }
-    if (url === '/regions' && where?.parent) {
-      return {
-        data: {
-          docs: [
-            {
-              id: 470,
-              slug: 'brussels',
-              level: 'city',
-              name: 'Brussels',
-              webPath: '/belgium/brussels',
-            },
-          ],
-        },
-      }
-    }
+    if (url === '/regions' && where?.slug) return { data: { docs: [country] } }
+    if (url === '/regions' && where?.parent) return { data: { docs: children } }
 
-    // /events/geojson
-    return {
-      data: {
-        type: 'FeatureCollection',
-        features: [
-          {
-            type: 'Feature',
-            geometry: { type: 'Point', coordinates: [4.35, 50.85] },
-            properties: {
-              id: 1,
-              title: 'Class',
-              eventType: 'offline',
-              languages: ['nl'],
-              webPath: '/belgium/brussels/1',
-              region: {
-                id: 470,
-                slug: 'brussels',
-                level: 'city',
-                breadcrumbs: [{ doc: 28 }, { doc: 470 }],
-              },
-            },
-          },
-        ],
-      },
-    }
+    return { data: { type: 'FeatureCollection', features: countryFeed } }
   }
 
-  it('derives level, eventCount, bounds, ISO code, webPath, and nested children', async () => {
-    get.mockImplementation((url: string, config?: never) => Promise.resolve(route(url, config)))
+  it('cards ≥2-event children, promotes single-event children, rolls up online', async () => {
+    get.mockImplementation((url: string, config?: never) =>
+      Promise.resolve(countryRoute(url, config)),
+    )
 
     const region = await api.getRegion('belgium')
 
+    // Core derivations: level, ISO code, path, canonical URL, bounds of located events.
     expect(region.level).toBe('country')
-    expect(region.eventCount).toBe(1)
-    expect(region.bounds).toEqual([4.35, 50.85, 4.35, 50.85])
     expect(region.countryCode).toBe('BE')
     expect(region.path).toBe('/belgium')
     expect(region.webUrl).toBe('https://atlas.example/belgium')
-    // a country lists subregions, not events
-    expect(region.events).toHaveLength(0)
+    expect(region.bounds).toEqual([4.35, 50.85, 4.41, 51.21])
+    // eventCount stays total (online included) — an online-only subtree still renders.
+    expect(region.eventCount).toBe(5)
+
+    // Only Antwerpen (2 located) is carded, badge = located count; Brussels (1) and
+    // Ghent (online-only) are not.
     expect(region.subregions).toHaveLength(1)
     expect(region.subregions[0]).toMatchObject({
-      slug: 'brussels',
-      eventCount: 1,
-      path: '/belgium/brussels',
+      slug: 'antwerpen',
+      eventCount: 2,
+      path: '/belgium/antwerpen',
     })
+
+    // Brussels' single event is promoted into the list, nested under *this* region.
+    expect(region.events).toHaveLength(1)
+    expect(region.events[0]).toMatchObject({ id: 3, eventType: 'offline', path: '/belgium/3' })
+
+    // Both online events roll up (Ghent + Antwerpen), soonest next occurrence first.
+    expect(region.onlineEvents.map((event) => event.id)).toEqual([5, 4])
+    expect(region.onlineEvents.every((event) => event.eventType === 'online')).toBe(true)
+  })
+
+  it('splits a leaf city into located events and an online roll-up', async () => {
+    const city = {
+      id: 470,
+      slug: 'brussels',
+      level: 'city',
+      name: 'Brussels',
+      subtitle: 'Capital',
+      webPath: '/belgium/brussels',
+      webUrl: 'https://atlas.example/belgium/brussels',
+    }
+    const leafFeed = [
+      feature({
+        id: 10,
+        regionId: 470,
+        slug: 'brussels',
+        breadcrumbs: [28, 470],
+        coordinates: [4.35, 50.85],
+      }),
+      feature({
+        id: 11,
+        regionId: 470,
+        slug: 'brussels',
+        breadcrumbs: [28, 470],
+        eventType: 'online',
+      }),
+    ]
+    const leafRoute = (url: string, config?: { params?: { where?: Record<string, unknown> } }) =>
+      url === '/regions' && config?.params?.where?.slug
+        ? { data: { docs: [city] } }
+        : { data: { type: 'FeatureCollection', features: leafFeed } }
+
+    get.mockImplementation((url: string, config?: never) => Promise.resolve(leafRoute(url, config)))
+
+    const region = await api.getRegion('brussels')
+
+    expect(region.level).toBe('city')
+    expect(region.subregions).toHaveLength(0)
+    // Located event stays in `events` (feed order), nested under the city path.
+    expect(region.events.map((event) => event.id)).toEqual([10])
+    expect(region.events[0]).toMatchObject({ eventType: 'offline', path: '/belgium/brussels/10' })
+    // The online event rolls up instead of interleaving.
+    expect(region.onlineEvents.map((event) => event.id)).toEqual([11])
+    expect(region.onlineEvents[0].eventType).toBe('online')
   })
 })
 

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -201,7 +201,7 @@ describe('getRegion (unified hierarchy derivation)', () => {
     return { data: { type: 'FeatureCollection', features: countryFeed } }
   }
 
-  it('cards ≥2-event children, promotes single-event children, rolls up online', async () => {
+  it('cards every child with a located event and rolls up online', async () => {
     get.mockImplementation((url: string, config?: never) =>
       Promise.resolve(countryRoute(url, config)),
     )
@@ -217,18 +217,16 @@ describe('getRegion (unified hierarchy derivation)', () => {
     // eventCount stays total (online included) — an online-only subtree still renders.
     expect(region.eventCount).toBe(5)
 
-    // Only Antwerpen (2 located) is carded, badge = located count; Brussels (1) and
-    // Ghent (online-only) are not.
-    expect(region.subregions).toHaveLength(1)
-    expect(region.subregions[0]).toMatchObject({
-      slug: 'antwerpen',
-      eventCount: 2,
-      path: '/belgium/antwerpen',
-    })
+    // Antwerpen (2 located) and Brussels (1 located) each card with a located-only
+    // badge, busiest first; Ghent (online-only) gets no card.
+    expect(region.subregions.map((child) => [child.slug, child.eventCount])).toEqual([
+      ['antwerpen', 2],
+      ['brussels', 1],
+    ])
+    expect(region.subregions[0].path).toBe('/belgium/antwerpen')
 
-    // Brussels' single event is promoted into the list, nested under *this* region.
-    expect(region.events).toHaveLength(1)
-    expect(region.events[0]).toMatchObject({ id: 3, eventType: 'offline', path: '/belgium/3' })
+    // No promotion: a country lists no events inline (child events live on child cards).
+    expect(region.events).toHaveLength(0)
 
     // Both online events roll up (Ghent + Antwerpen), soonest next occurrence first.
     expect(region.onlineEvents.map((event) => event.id)).toEqual([5, 4])

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -109,7 +109,6 @@ describe('getRegion (unified hierarchy derivation)', () => {
     breadcrumbs,
     eventType = 'offline',
     coordinates,
-    webPath,
     next,
   }: {
     id: number
@@ -118,7 +117,6 @@ describe('getRegion (unified hierarchy derivation)', () => {
     breadcrumbs: number[]
     eventType?: 'offline' | 'online'
     coordinates?: [number, number]
-    webPath?: string
     next?: string
   }) => ({
     type: 'Feature',
@@ -128,7 +126,6 @@ describe('getRegion (unified hierarchy derivation)', () => {
       title: `Event ${id}`,
       eventType,
       languages: ['nl'],
-      webPath,
       region: {
         id: regionId,
         slug,

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -233,11 +233,10 @@ const getCountries = async (): Promise<RegionListItem[]> => {
     .sort(byEventCountDesc)
 }
 
-// One fetcher for every region level. Parents (`country`/`region`) list child
-// regions with ≥ 2 located events as cards and promote a single-event child's one
-// event into the list; leaves (`city`/`center`) list their located events. Every
-// level rolls up the placeless online events under it. Path/webUrl come from the
-// server; bounds/center/counts are derived from the feed.
+// One fetcher for every region level. Parents (`country`/`region`) list their
+// child regions as cards; leaves (`city`/`center`) list their located events.
+// Every level rolls up the placeless online events under it. Path/webUrl come
+// from the server; bounds/center/counts are derived from the feed.
 const getRegion = async (slug: string): Promise<Region> => {
   // The region read and the feed are independent — load them in parallel.
   const [doc, geojson] = await Promise.all([getRegionDoc(slug), loadGeojson()])
@@ -256,23 +255,20 @@ const getRegion = async (slug: string): Promise<Region> => {
     children.map((child) => child.id),
   )
 
-  // ≥ 2 located events → a card (badge = located count); exactly 1 → promoted into
-  // the list below; 0 located (online-only / empty child) → no card.
-  const carded: RegionListItem[] = []
-  const promoted: IndexedFeature[] = []
+  // Any child with ≥ 1 located event renders a card (badge = located count); an
+  // online-only / empty child gets none — its online events still roll up below.
+  const subregions: RegionListItem[] = []
 
   for (const child of children) {
-    const located = byChild.get(child.id) ?? []
+    const located = byChild.get(child.id)?.length ?? 0
 
-    if (located.length >= 2) carded.push(toListItem(child, located.length))
-    else if (located.length === 1) promoted.push(located[0])
+    if (located > 0) subregions.push(toListItem(child, located))
   }
-  const subregions = carded.sort(byEventCountDesc)
+  subregions.sort(byEventCountDesc)
 
   // Nest each event under *this* region's path so navigating to it keeps the full
   // region ancestry in the URL (an event's own webPath is flat / often null, which
-  // would otherwise stack it straight on the country list) — and so a promoted
-  // event's dismissal returns here, not to the skipped single-event child.
+  // would otherwise stack it straight on the country list).
   const nest = (indexed: IndexedFeature): EventSlim => {
     const slim = toSlim(indexed.feature)
 
@@ -294,8 +290,9 @@ const getRegion = async (slug: string): Promise<Region> => {
     parentPath: parentOf(path),
     webUrl: doc.webUrl,
     subregions,
-    // Located only: promoted single-event children + events directly under the region.
-    events: [...promoted, ...direct].map(nest),
+    // Located events directly under this region (a leaf's own events; parents
+    // usually have none — a child's events are reached through the child's card).
+    events: direct.map(nest),
     // Placeless online events under the region, soonest next occurrence first.
     onlineEvents: online.map(nest).sort(byNextOccurrence),
   })

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -17,12 +17,13 @@ import { centerOfBounds, distanceKm } from '@/lib/geo'
 import {
   ancestorIdsFromBreadcrumbs,
   boundsUnder,
+  byNextOccurrence,
   countUnder,
-  eventsUnder,
   childRoute,
   DEFAULT_FILTERS,
   matchesFilters,
   parentOf,
+  partitionUnder,
   resolveImageUrl,
   safePath,
 } from '@/lib/shape'
@@ -105,6 +106,9 @@ const indexFeatures = (geojson: Geojson): IndexedFeature[] =>
   geojson.features.map((feature) => ({
     feature,
     point: feature.geometry?.coordinates ?? null,
+    // Online belongs to no place: classified by eventType, never geometry (a
+    // coordinate-less *offline* event still counts as located).
+    online: feature.properties.eventType === 'online',
     ancestorIds: [
       ...new Set([
         feature.properties.region.id,
@@ -177,14 +181,14 @@ const countryCodeOf = (doc: RegionDoc): string | undefined => {
   return typeof code === 'string' && /^[A-Za-z]{2}$/.test(code) ? code : undefined
 }
 
-const toListItem = (doc: RegionDoc, events: GeoEvent[]): RegionListItem =>
+const toListItem = (doc: RegionDoc, eventCount: number): RegionListItem =>
   RegionListItemSchema.parse({
     id: doc.id,
     slug: doc.slug,
     level: doc.level,
     name: doc.name ?? doc.slug,
     subtitle: doc.subtitle,
-    eventCount: countUnder(events, doc.id),
+    eventCount,
     path: regionRoute(doc),
   })
 
@@ -228,8 +232,10 @@ const getCountries = async (): Promise<RegionListItem[]> => {
     .sort(byEventCountDesc)
 }
 
-// One fetcher for every region level. `country`/`region` populate `subregions`
-// (child list); `city`/`center` populate `events`. Path/webUrl come from the
+// One fetcher for every region level. Parents (`country`/`region`) list child
+// regions with ≥ 2 located events as cards and promote a single-event child's one
+// event into the list; leaves (`city`/`center`) list their located events. Every
+// level rolls up the placeless online events under it. Path/webUrl come from the
 // server; bounds/center/counts are derived from the feed.
 const getRegion = async (slug: string): Promise<Region> => {
   // The region read and the feed are independent — load them in parallel.
@@ -238,15 +244,39 @@ const getRegion = async (slug: string): Promise<Region> => {
 
   const path = regionRoute(doc)
   const isParent = doc.level === 'country' || doc.level === 'region'
-  const under = eventsUnder(events, doc.id)
   const bounds = boundsUnder(events, doc.id)
 
-  const subregions = isParent
-    ? (await getChildRegions(doc.id))
-        .map((child) => toListItem(child, events))
-        .filter((child) => child.eventCount > 0)
-        .sort(byEventCountDesc)
-    : []
+  // Parents split their located events across child regions; a leaf has no children,
+  // so every located event lands in `direct`. Online events roll up at every level.
+  const children = isParent ? await getChildRegions(doc.id) : []
+  const { byChild, direct, online } = partitionUnder(
+    events,
+    doc.id,
+    children.map((child) => child.id),
+  )
+
+  // ≥ 2 located events → a card (badge = located count); exactly 1 → promoted into
+  // the list below; 0 located (online-only / empty child) → no card.
+  const subregions = children
+    .map((child) => ({ child, located: byChild.get(child.id) ?? [] }))
+    .filter(({ located }) => located.length >= 2)
+    .map(({ child, located }) => toListItem(child, located.length))
+    .sort(byEventCountDesc)
+
+  const promoted = children
+    .map((child) => byChild.get(child.id) ?? [])
+    .filter((located) => located.length === 1)
+    .map(([event]) => event)
+
+  // Nest each event under *this* region's path so navigating to it keeps the full
+  // region ancestry in the URL (an event's own webPath is flat / often null, which
+  // would otherwise stack it straight on the country list) — and so a promoted
+  // event's dismissal returns here, not to the skipped single-event child.
+  const nest = (indexed: IndexedFeature): EventSlim => {
+    const slim = toSlim(indexed.feature)
+
+    return { ...slim, path: childRoute(path, slim.id) }
+  }
 
   return RegionSchema.parse({
     id: doc.id,
@@ -255,23 +285,18 @@ const getRegion = async (slug: string): Promise<Region> => {
     level: doc.level,
     subtitle: doc.subtitle,
     countryCode: doc.level === 'country' ? countryCodeOf(doc) : undefined,
-    eventCount: under.length,
+    // Total (located + online), so a subtree holding only online events still renders.
+    eventCount: countUnder(events, doc.id),
     bounds,
     center: bounds ? centerOfBounds(bounds) : null,
     path,
     parentPath: parentOf(path),
     webUrl: doc.webUrl,
     subregions,
-    // Nest each event under this region's path so navigating to it keeps the full
-    // region ancestry in the URL (an event's own webPath is flat / often null, which
-    // would otherwise stack the event straight on the country list).
-    events: isParent
-      ? []
-      : under.map((indexed) => {
-          const slim = toSlim(indexed.feature)
-
-          return { ...slim, path: childRoute(path, slim.id) }
-        }),
+    // Located only: promoted single-event children + events directly under the region.
+    events: [...promoted, ...direct].map(nest),
+    // Placeless online events under the region, soonest next occurrence first.
+    onlineEvents: online.map(nest).sort(byNextOccurrence),
   })
 }
 

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -21,6 +21,7 @@ import {
   countUnder,
   childRoute,
   DEFAULT_FILTERS,
+  isOnline,
   matchesFilters,
   parentOf,
   partitionUnder,
@@ -108,7 +109,7 @@ const indexFeatures = (geojson: Geojson): IndexedFeature[] =>
     point: feature.geometry?.coordinates ?? null,
     // Online belongs to no place: classified by eventType, never geometry (a
     // coordinate-less *offline* event still counts as located).
-    online: feature.properties.eventType === 'online',
+    online: isOnline(feature.properties),
     ancestorIds: [
       ...new Set([
         feature.properties.region.id,
@@ -257,16 +258,16 @@ const getRegion = async (slug: string): Promise<Region> => {
 
   // ≥ 2 located events → a card (badge = located count); exactly 1 → promoted into
   // the list below; 0 located (online-only / empty child) → no card.
-  const subregions = children
-    .map((child) => ({ child, located: byChild.get(child.id) ?? [] }))
-    .filter(({ located }) => located.length >= 2)
-    .map(({ child, located }) => toListItem(child, located.length))
-    .sort(byEventCountDesc)
+  const carded: RegionListItem[] = []
+  const promoted: IndexedFeature[] = []
 
-  const promoted = children
-    .map((child) => byChild.get(child.id) ?? [])
-    .filter((located) => located.length === 1)
-    .map(([event]) => event)
+  for (const child of children) {
+    const located = byChild.get(child.id) ?? []
+
+    if (located.length >= 2) carded.push(toListItem(child, located.length))
+    else if (located.length === 1) promoted.push(located[0])
+  }
+  const subregions = carded.sort(byEventCountDesc)
 
   // Nest each event under *this* region's path so navigating to it keeps the full
   // region ancestry in the URL (an event's own webPath is flat / often null, which

--- a/src/config/store.test.ts
+++ b/src/config/store.test.ts
@@ -2,14 +2,13 @@ import type { Feature } from 'geojson'
 
 import { describe, it, expect, beforeEach } from 'vitest'
 
-import { useSearchState, useViewState } from './store'
+import { useViewState } from './store'
 
-import { DEFAULT_FILTERS } from '@/lib/shape'
-
-// The stores are the single source of truth for map view and search filters.
+// The stores are the single source of truth for map view (+ the registration draft).
 // They're plain zustand vanilla stores, so we drive their actions directly via
-// getState() without React. Reset to the initial slice in beforeEach since the
-// module singletons persist between tests.
+// getState() without React. Reset to the initial slice in beforeEach since the module
+// singletons persist between tests. (Search filters moved to the URL — their
+// serialization is covered in filters.test.ts.)
 
 describe('useViewState', () => {
   beforeEach(() => {
@@ -42,60 +41,5 @@ describe('useViewState', () => {
 
     expect(state.selection).toEqual({ latitude: 1, longitude: 2, approximate: true })
     expect(state.boundary).toBe(boundary)
-  })
-})
-
-describe('useSearchState', () => {
-  beforeEach(() => {
-    useSearchState.setState({ ...DEFAULT_FILTERS })
-  })
-
-  it('setters update each filter field', () => {
-    const state = () => useSearchState.getState()
-
-    state().setFormat('online')
-    state().setCadence('WEEKLY')
-    state().setTimeOfDay([9, 17])
-
-    expect(state()).toMatchObject({ format: 'online', cadence: 'WEEKLY', timeOfDay: [9, 17] })
-  })
-
-  it('setDaysOfWeek keeps weekdays sorted', () => {
-    useSearchState.getState().setDaysOfWeek([5, 1, 3])
-
-    expect(useSearchState.getState().daysOfWeek).toEqual([1, 3, 5])
-  })
-
-  it('setLanguages replaces the selection, staying sorted', () => {
-    useSearchState.getState().setLanguages(['fr', 'en'])
-    expect(useSearchState.getState().languages).toEqual(['en', 'fr'])
-
-    useSearchState.getState().setLanguages([])
-    expect(useSearchState.getState().languages).toEqual([])
-  })
-
-  it('clearFilters restores the defaults', () => {
-    const state = () => useSearchState.getState()
-
-    state().setFormat('online')
-    state().setDaysOfWeek([2, 4])
-    state().clearFilters()
-
-    expect(state()).toMatchObject(DEFAULT_FILTERS)
-  })
-
-  it('setFilters commits a whole filter set at once, sorting arrays', () => {
-    useSearchState.getState().setFilters({
-      ...DEFAULT_FILTERS,
-      format: 'offline',
-      daysOfWeek: [5, 1],
-      languages: ['fr', 'en'],
-    })
-
-    expect(useSearchState.getState()).toMatchObject({
-      format: 'offline',
-      daysOfWeek: [1, 5],
-      languages: ['en', 'fr'],
-    })
   })
 })

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -1,13 +1,5 @@
 import { create } from 'zustand'
-import { useShallow } from 'zustand/react/shallow'
 import { Feature } from 'geojson'
-
-import {
-  DEFAULT_FILTERS,
-  type EventCadence,
-  type EventFilters,
-  type EventFormat,
-} from '@/lib/shape'
 
 // ===== VIEW STATE ===== //
 
@@ -35,58 +27,9 @@ export const useViewState = create<ViewState & ViewAction>((set) => ({
   setBoundary: (boundary: ViewState['boundary']) => set(() => ({ boundary })),
 }))
 
-// ===== SEARCH STATE ===== //
-
-// The *applied* event filters (format / time-of-day / days-of-week / languages /
-// cadence): the single source of truth for what the events list and the map show;
-// both apply the shared `matchesFilters` predicate. The FilterView drawer edits a
-// local draft and commits it here with `setFilters` on Apply; the granular setters
-// are the immediate quick-edits used by the active-filter pills in the results.
-// Read with a `useShallow` selector so the map (hot path) only re-renders on the
-// fields it uses. Day/language arrays are kept sorted so their identity — and the
-// list's query key — stay stable across no-op reorders.
-type SearchState = EventFilters
-
-type SearchAction = {
-  setFilters: (filters: EventFilters) => void
-  setFormat: (format: EventFormat) => void
-  setCadence: (cadence: EventCadence) => void
-  setTimeOfDay: (timeOfDay: [number, number]) => void
-  setDaysOfWeek: (daysOfWeek: number[]) => void
-  setLanguages: (languages: string[]) => void
-  clearFilters: () => void
-}
-
-const sorted = (filters: EventFilters): EventFilters => ({
-  ...filters,
-  daysOfWeek: [...filters.daysOfWeek].sort((a, b) => a - b),
-  languages: [...filters.languages].sort(),
-})
-
-export const useSearchState = create<SearchState & SearchAction>((set) => ({
-  ...DEFAULT_FILTERS,
-  setFilters: (filters) => set(sorted(filters)),
-  setFormat: (format) => set({ format }),
-  setCadence: (cadence) => set({ cadence }),
-  setTimeOfDay: (timeOfDay) => set({ timeOfDay }),
-  setDaysOfWeek: (daysOfWeek) => set({ daysOfWeek: [...daysOfWeek].sort((a, b) => a - b) }),
-  setLanguages: (languages) => set({ languages: [...languages].sort() }),
-  clearFilters: () => set(DEFAULT_FILTERS),
-}))
-
-// The filter-value slice (no setters) — the single read the events list and the
-// map both consume, so the useShallow selector lives in one place. useShallow
-// keeps the returned identity stable, so the map's hot path only re-renders when a
-// filter field actually changes.
-const pickFilters = (state: SearchState & SearchAction): EventFilters => ({
-  format: state.format,
-  timeOfDay: state.timeOfDay,
-  daysOfWeek: state.daysOfWeek,
-  languages: state.languages,
-  cadence: state.cadence,
-})
-
-export const useEventFilters = (): EventFilters => useSearchState(useShallow(pickFilters))
+// Search filters no longer live here — they're the single source of truth in the
+// URL query (`src/hooks/use-filters.ts` + `filtersToParams`/`filtersFromParams`),
+// so a filtered view is linkable. The map + list read them with `useEventFilters`.
 
 // ===== REGISTRATION DRAFT ===== //
 

--- a/src/hooks/use-filters.ts
+++ b/src/hooks/use-filters.ts
@@ -10,10 +10,9 @@ import { DEFAULT_FILTERS, filtersFromParams, filtersToParams } from '@/lib/shape
 // with `useEventFilters`; mutate the /search flow's filters with `useSetFilters`.
 
 /**
- * Applied filters parsed from the URL query. `useSearchParams` memoizes its result
- * on `location.search`, and the map camera lives in zustand (pan/zoom never touches
- * the URL), so this identity is stable across the map's hot path and only
- * re-derives when the query actually changes.
+ * Applied filters parsed from the URL query. Re-derives on any query change
+ * (including `?q`/`?bbox`/`?center`/`?all`), but that's off the map's true hot path:
+ * pan/zoom writes the camera to zustand, never the URL, so those don't churn this.
  */
 export const useEventFilters = (): EventFilters => {
   const [searchParams] = useSearchParams()
@@ -22,27 +21,28 @@ export const useEventFilters = (): EventFilters => {
 }
 
 /**
- * In-place filter setters that rewrite the current URL's filter params while
- * preserving the rest (`q`/`bbox`/`center`/`all`). Used by the results' quick-edit
- * pills; `setFilters` commits a whole set. `replace` so tweaking a filter doesn't
- * stack a history entry per keystroke.
+ * Filter setters that rewrite the current URL's filter params while preserving the
+ * rest (`q`/`bbox`/`center`/`all`). Used by the results' quick-edit pills; `setFilters`
+ * commits a whole set. `replace` so tweaking a filter doesn't stack a history entry.
  */
 export const useSetFilters = () => {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const current = filtersFromParams(searchParams)
+  const [, setSearchParams] = useSearchParams()
 
-  const setFilters = (filters: EventFilters) =>
-    setSearchParams((prev) => filtersToParams(filters, new URLSearchParams(prev)), {
-      replace: true,
-    })
+  // Read the *current* filters from `prev` inside the updater (not a render-time
+  // snapshot), so a concurrent change can't be clobbered.
+  const update = (change: (filters: EventFilters) => EventFilters) =>
+    setSearchParams(
+      (prev) => filtersToParams(change(filtersFromParams(prev)), new URLSearchParams(prev)),
+      { replace: true },
+    )
 
   return {
-    setFilters,
-    setFormat: (format: EventFormat) => setFilters({ ...current, format }),
-    setCadence: (cadence: EventCadence) => setFilters({ ...current, cadence }),
-    setTimeOfDay: (timeOfDay: [number, number]) => setFilters({ ...current, timeOfDay }),
-    setDaysOfWeek: (daysOfWeek: number[]) => setFilters({ ...current, daysOfWeek }),
-    setLanguages: (languages: string[]) => setFilters({ ...current, languages }),
-    clearFilters: () => setFilters(DEFAULT_FILTERS),
+    setFilters: (filters: EventFilters) => update(() => filters),
+    setFormat: (format: EventFormat) => update((filters) => ({ ...filters, format })),
+    setCadence: (cadence: EventCadence) => update((filters) => ({ ...filters, cadence })),
+    setTimeOfDay: (timeOfDay: [number, number]) => update((filters) => ({ ...filters, timeOfDay })),
+    setDaysOfWeek: (daysOfWeek: number[]) => update((filters) => ({ ...filters, daysOfWeek })),
+    setLanguages: (languages: string[]) => update((filters) => ({ ...filters, languages })),
+    clearFilters: () => update(() => DEFAULT_FILTERS),
   }
 }

--- a/src/hooks/use-filters.ts
+++ b/src/hooks/use-filters.ts
@@ -1,6 +1,6 @@
 import type { EventCadence, EventFilters, EventFormat } from '@/lib/shape'
 
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useSearchParams } from 'react-router'
 
 import { DEFAULT_FILTERS, filtersFromParams, filtersToParams } from '@/lib/shape'
@@ -10,17 +10,15 @@ import { DEFAULT_FILTERS, filtersFromParams, filtersToParams } from '@/lib/shape
 // with `useEventFilters`; mutate the /search flow's filters with `useSetFilters`.
 
 /**
- * Applied filters parsed from the URL query. Memoized on the *filter-only* query so
- * the identity is stable while the filters are unchanged — the map's hot path
- * depends on this (a `?q`/`?all`/`?center` edit must not churn the filters object).
+ * Applied filters parsed from the URL query. `useSearchParams` memoizes its result
+ * on `location.search`, and the map camera lives in zustand (pan/zoom never touches
+ * the URL), so this identity is stable across the map's hot path and only
+ * re-derives when the query actually changes.
  */
 export const useEventFilters = (): EventFilters => {
   const [searchParams] = useSearchParams()
-  // Canonical filter-only query: round-tripping drops unrelated params and normalizes
-  // order, so the string only changes when a filter value actually changes.
-  const query = filtersToParams(filtersFromParams(searchParams)).toString()
 
-  return useMemo(() => filtersFromParams(new URLSearchParams(query)), [query])
+  return useMemo(() => filtersFromParams(searchParams), [searchParams])
 }
 
 /**
@@ -33,13 +31,10 @@ export const useSetFilters = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const current = filtersFromParams(searchParams)
 
-  const setFilters = useCallback(
-    (filters: EventFilters) =>
-      setSearchParams((prev) => filtersToParams(filters, new URLSearchParams(prev)), {
-        replace: true,
-      }),
-    [setSearchParams],
-  )
+  const setFilters = (filters: EventFilters) =>
+    setSearchParams((prev) => filtersToParams(filters, new URLSearchParams(prev)), {
+      replace: true,
+    })
 
   return {
     setFilters,

--- a/src/hooks/use-filters.ts
+++ b/src/hooks/use-filters.ts
@@ -1,0 +1,53 @@
+import type { EventCadence, EventFilters, EventFormat } from '@/lib/shape'
+
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router'
+
+import { DEFAULT_FILTERS, filtersFromParams, filtersToParams } from '@/lib/shape'
+
+// The applied event filters live in the URL query — the single source of truth, so
+// a filtered view is linkable/shareable and the map + list always agree on it. Read
+// with `useEventFilters`; mutate the /search flow's filters with `useSetFilters`.
+
+/**
+ * Applied filters parsed from the URL query. Memoized on the *filter-only* query so
+ * the identity is stable while the filters are unchanged — the map's hot path
+ * depends on this (a `?q`/`?all`/`?center` edit must not churn the filters object).
+ */
+export const useEventFilters = (): EventFilters => {
+  const [searchParams] = useSearchParams()
+  // Canonical filter-only query: round-tripping drops unrelated params and normalizes
+  // order, so the string only changes when a filter value actually changes.
+  const query = filtersToParams(filtersFromParams(searchParams)).toString()
+
+  return useMemo(() => filtersFromParams(new URLSearchParams(query)), [query])
+}
+
+/**
+ * In-place filter setters that rewrite the current URL's filter params while
+ * preserving the rest (`q`/`bbox`/`center`/`all`). Used by the results' quick-edit
+ * pills; `setFilters` commits a whole set. `replace` so tweaking a filter doesn't
+ * stack a history entry per keystroke.
+ */
+export const useSetFilters = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const current = filtersFromParams(searchParams)
+
+  const setFilters = useCallback(
+    (filters: EventFilters) =>
+      setSearchParams((prev) => filtersToParams(filters, new URLSearchParams(prev)), {
+        replace: true,
+      }),
+    [setSearchParams],
+  )
+
+  return {
+    setFilters,
+    setFormat: (format: EventFormat) => setFilters({ ...current, format }),
+    setCadence: (cadence: EventCadence) => setFilters({ ...current, cadence }),
+    setTimeOfDay: (timeOfDay: [number, number]) => setFilters({ ...current, timeOfDay }),
+    setDaysOfWeek: (daysOfWeek: number[]) => setFilters({ ...current, daysOfWeek }),
+    setLanguages: (languages: string[]) => setFilters({ ...current, languages }),
+    clearFilters: () => setFilters(DEFAULT_FILTERS),
+  }
+}

--- a/src/lib/shape/event.test.ts
+++ b/src/lib/shape/event.test.ts
@@ -53,6 +53,11 @@ describe('byNextOccurrence', () => {
       noSchedule,
     ])
   })
+
+  it('treats two undated events as equal (no NaN)', () => {
+    // Infinity - Infinity would be NaN — an invalid sort comparator result.
+    expect(byNextOccurrence(noSchedule, noSchedule)).toBe(0)
+  })
 })
 
 describe('eventTimeZone', () => {

--- a/src/lib/shape/event.test.ts
+++ b/src/lib/shape/event.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { DateTime } from 'luxon'
 
-import { eventTimeZone, isOnline, nextOccurrence } from './event'
+import { byNextOccurrence, eventTimeZone, isOnline, nextOccurrence } from './event'
 
 const offline = {
   eventType: 'offline' as const,
@@ -33,6 +33,25 @@ describe('nextOccurrence', () => {
 
   it('is undefined without a schedule or upcoming dates', () => {
     expect(nextOccurrence(noSchedule)).toBeUndefined()
+  })
+})
+
+describe('byNextOccurrence', () => {
+  const later = {
+    eventType: 'online' as const,
+    schedule: {
+      firstDate: new Date('2026-01-10T18:00:00Z'),
+      upcomingDates: [new Date('2026-07-18T18:00:00Z')],
+    },
+  }
+
+  it('orders by soonest next occurrence, undated last', () => {
+    // offline → 2026-07-04, later → 2026-07-18, noSchedule → undated (trails).
+    expect([later, noSchedule, offline].sort(byNextOccurrence)).toEqual([
+      offline,
+      later,
+      noSchedule,
+    ])
   })
 })
 

--- a/src/lib/shape/event.ts
+++ b/src/lib/shape/event.ts
@@ -18,9 +18,15 @@ export const nextOccurrence = (event: EventLike): Date | undefined =>
 /**
  * Comparator ordering events by soonest next occurrence, undated last — used to
  * sequence the online roll-up (placeless events have no map order to inherit).
+ * Two undated events compare equal (guarding the `Infinity - Infinity = NaN` an
+ * unguarded subtraction would return, which is an invalid `Array.sort` result).
  */
-export const byNextOccurrence = (a: EventLike, b: EventLike): number =>
-  (nextOccurrence(a)?.getTime() ?? Infinity) - (nextOccurrence(b)?.getTime() ?? Infinity)
+export const byNextOccurrence = (a: EventLike, b: EventLike): number => {
+  const ta = nextOccurrence(a)?.getTime() ?? Infinity
+  const tb = nextOccurrence(b)?.getTime() ?? Infinity
+
+  return ta === tb ? 0 : ta - tb
+}
 
 /**
  * The timezone to display an event's times in: the viewer's local zone for

--- a/src/lib/shape/event.ts
+++ b/src/lib/shape/event.ts
@@ -16,6 +16,13 @@ export const nextOccurrence = (event: EventLike): Date | undefined =>
   event.schedule?.upcomingDates?.[0]
 
 /**
+ * Comparator ordering events by soonest next occurrence, undated last — used to
+ * sequence the online roll-up (placeless events have no map order to inherit).
+ */
+export const byNextOccurrence = (a: EventLike, b: EventLike): number =>
+  (nextOccurrence(a)?.getTime() ?? Infinity) - (nextOccurrence(b)?.getTime() ?? Infinity)
+
+/**
  * The timezone to display an event's times in: the viewer's local zone for
  * online events, otherwise the event's own zone (UTC as a last resort).
  */

--- a/src/lib/shape/filters.test.ts
+++ b/src/lib/shape/filters.test.ts
@@ -4,7 +4,9 @@ import { DateTime } from 'luxon'
 import {
   DEFAULT_FILTERS,
   activeFilterCount,
+  filtersFromParams,
   filtersKey,
+  filtersToParams,
   hasActiveFilters,
   matchesFilters,
   type EventFilters,
@@ -214,5 +216,49 @@ describe('filtersKey', () => {
 
   it('differs when a filter differs', () => {
     expect(filtersKey(DEFAULT_FILTERS)).not.toBe(filtersKey(withFilters({ format: 'online' })))
+  })
+})
+
+describe('URL serialization', () => {
+  const active: EventFilters = {
+    format: 'online',
+    cadence: 'WEEKLY',
+    daysOfWeek: [1, 3, 5],
+    timeOfDay: [9, 17],
+    languages: ['en', 'fr'],
+  }
+
+  it('round-trips an active filter set through the query', () => {
+    expect(filtersFromParams(filtersToParams(active))).toEqual(active)
+  })
+
+  it('omits default (unrestricted) groups so links stay clean', () => {
+    expect(filtersToParams(DEFAULT_FILTERS).toString()).toBe('')
+    expect(filtersToParams(withFilters({ format: 'online' })).toString()).toBe('format=online')
+  })
+
+  it('preserves non-filter params and clears stale filter params in the base', () => {
+    const base = new URLSearchParams('format=online&days=1,2&q=paris&center=2.3,48.8')
+    const params = filtersToParams(withFilters({ format: 'offline' }), base)
+
+    expect(params.get('format')).toBe('offline') // rewritten
+    expect(params.has('days')).toBe(false) // stale filter param dropped
+    expect(params.get('q')).toBe('paris') // non-filter param kept
+    expect(params.get('center')).toBe('2.3,48.8')
+  })
+
+  it('falls back to defaults for missing or malformed params', () => {
+    expect(filtersFromParams(new URLSearchParams())).toEqual(DEFAULT_FILTERS)
+    // Unknown format/cadence, out-of-range days, reversed time → each group defaults.
+    const junk = new URLSearchParams('format=hybrid&cadence=YEARLY&days=0,8,foo&time=20,4')
+
+    expect(filtersFromParams(junk)).toEqual(DEFAULT_FILTERS)
+  })
+
+  it('de-dupes and sorts the day and language lists', () => {
+    const filters = filtersFromParams(new URLSearchParams('days=5,1,3,3&langs=fr,en,fr'))
+
+    expect(filters.daysOfWeek).toEqual([1, 3, 5])
+    expect(filters.languages).toEqual(['en', 'fr'])
   })
 })

--- a/src/lib/shape/filters.ts
+++ b/src/lib/shape/filters.ts
@@ -160,3 +160,60 @@ export const filtersKey = (filters: EventFilters): string =>
     daysOfWeek: [...filters.daysOfWeek].sort((a, b) => a - b),
     languages: [...filters.languages].sort(),
   })
+
+// ── URL serialization (the query params ARE the applied filters) ────────────────
+// The filters live in the URL so a filtered view is linkable/shareable. One compact
+// key per group; a default (unrestricted) group is omitted so links stay clean.
+
+const FILTER_PARAM_KEYS = ['format', 'cadence', 'days', 'time', 'langs'] as const
+const CADENCES: readonly string[] = ['once', 'DAILY', 'WEEKLY', 'MONTHLY']
+
+const parseDays = (value: string | null): number[] =>
+  value
+    ? [...new Set(value.split(',').map(Number))]
+        .filter((day) => Number.isInteger(day) && day >= 1 && day <= 7)
+        .sort((a, b) => a - b)
+    : []
+
+const parseTime = (value: string | null): [number, number] => {
+  const [earliest, latest] = (value ?? '').split(',').map(Number)
+  const valid =
+    Number.isFinite(earliest) &&
+    Number.isFinite(latest) &&
+    earliest >= TIME_MIN &&
+    latest <= TIME_MAX &&
+    earliest <= latest
+
+  return valid ? [earliest, latest] : [TIME_MIN, TIME_MAX]
+}
+
+/** The applied filters decoded from a URL query — each group falls back to its default. */
+export const filtersFromParams = (params: URLSearchParams): EventFilters => {
+  const format = params.get('format')
+  const cadence = params.get('cadence')
+  const langs = params.get('langs')
+
+  return {
+    format: format === 'online' || format === 'offline' ? format : 'any',
+    cadence: CADENCES.includes(cadence ?? '') ? (cadence as EventCadence) : 'any',
+    daysOfWeek: parseDays(params.get('days')),
+    timeOfDay: parseTime(params.get('time')),
+    languages: langs ? [...new Set(langs.split(',').filter(Boolean))].sort() : [],
+  }
+}
+
+/** Encode `filters` into a copy of `base`, preserving non-filter params (`q`/`center`/…). */
+export const filtersToParams = (filters: EventFilters, base?: URLSearchParams): URLSearchParams => {
+  const params = new URLSearchParams(base)
+
+  FILTER_PARAM_KEYS.forEach((key) => params.delete(key))
+  if (filters.format !== 'any') params.set('format', filters.format)
+  if (filters.cadence !== 'any') params.set('cadence', filters.cadence)
+  if (filters.daysOfWeek.length > 0) {
+    params.set('days', [...filters.daysOfWeek].sort((a, b) => a - b).join(','))
+  }
+  if (isTimeRestricted(filters.timeOfDay)) params.set('time', filters.timeOfDay.join(','))
+  if (filters.languages.length > 0) params.set('langs', [...filters.languages].sort().join(','))
+
+  return params
+}

--- a/src/lib/shape/filters.ts
+++ b/src/lib/shape/filters.ts
@@ -5,10 +5,10 @@ import { DateTime } from 'luxon'
 import { eventTimeZone } from './event'
 
 /**
- * The event-filter model, shared verbatim by the SearchFilters panel, the
- * `useSearchState` store, the events list, and the map. `matchesFilters` is the
- * single predicate both the list and the map apply, so a filtered list and the
- * filtered pins/clusters always agree.
+ * The event-filter model, shared by the SearchFilters panel, the URL filter codec
+ * (`filtersToParams`/`filtersFromParams`), the events list, and the map.
+ * `matchesFilters` is the single predicate both the list and the map apply, so a
+ * filtered list and the filtered pins/clusters always agree.
  *
  * All fields have a "no restriction" default (`DEFAULT_FILTERS`); with every
  * field at its default, `matchesFilters` passes every event.

--- a/src/lib/shape/filters.ts
+++ b/src/lib/shape/filters.ts
@@ -198,7 +198,9 @@ export const filtersFromParams = (params: URLSearchParams): EventFilters => {
     cadence: CADENCES.includes(cadence ?? '') ? (cadence as EventCadence) : 'any',
     daysOfWeek: parseDays(params.get('days')),
     timeOfDay: parseTime(params.get('time')),
-    languages: langs ? [...new Set(langs.split(',').filter(Boolean))].sort() : [],
+    // Cap the list like the other groups are bounded — a hand-crafted URL can't
+    // balloon it (values only feed `matchesFilters` includes + re-serialization).
+    languages: langs ? [...new Set(langs.split(',').filter(Boolean))].sort().slice(0, 50) : [],
   }
 }
 

--- a/src/lib/shape/hierarchy.test.ts
+++ b/src/lib/shape/hierarchy.test.ts
@@ -2,13 +2,19 @@ import type { GeoEvent } from './hierarchy'
 
 import { describe, it, expect } from 'vitest'
 
-import { ancestorIdsFromBreadcrumbs, boundsUnder, countUnder, eventsUnder } from './hierarchy'
+import {
+  ancestorIdsFromBreadcrumbs,
+  boundsUnder,
+  countUnder,
+  eventsUnder,
+  partitionUnder,
+} from './hierarchy'
 
 // Belgium(28) → Antwerpen(473) and Belgium(28) → Brussels(470) → venue(513).
 const events: GeoEvent[] = [
-  { point: [4.4, 51.2], ancestorIds: [28, 473] }, // event in Antwerpen
-  { point: [4.35, 50.85], ancestorIds: [28, 470, 513] }, // event at the Brussels venue
-  { point: null, ancestorIds: [28, 470] }, // online event under Brussels
+  { point: [4.4, 51.2], ancestorIds: [28, 473], online: false }, // event in Antwerpen
+  { point: [4.35, 50.85], ancestorIds: [28, 470, 513], online: false }, // event at the Brussels venue
+  { point: null, ancestorIds: [28, 470], online: true }, // online event under Brussels
 ]
 
 describe('ancestorIdsFromBreadcrumbs', () => {
@@ -46,6 +52,56 @@ describe('boundsUnder', () => {
   })
 
   it('returns null when a region has no located events', () => {
-    expect(boundsUnder([{ point: null, ancestorIds: [99] }], 99)).toBeNull()
+    expect(boundsUnder([{ point: null, ancestorIds: [99], online: false }], 99)).toBeNull()
+  })
+})
+
+describe('partitionUnder', () => {
+  // Belgium(28) → Antwerpen(473) [1 located] and Belgium(28) → Brussels(470) →
+  // venue(513) [2 located + 1 online], plus one placeless offline event directly
+  // under Belgium and one out-of-subtree event under France(99).
+  const [belgium, antwerpen, brussels, venue, france] = [28, 473, 470, 513, 99]
+  const subtree: GeoEvent[] = [
+    { point: [4.4, 51.2], ancestorIds: [belgium, antwerpen], online: false }, // → Antwerpen
+    { point: [4.35, 50.85], ancestorIds: [belgium, brussels, venue], online: false }, // → Brussels
+    { point: [4.36, 50.84], ancestorIds: [belgium, brussels], online: false }, // → Brussels
+    { point: null, ancestorIds: [belgium], online: false }, // placeless offline, no child
+    { point: null, ancestorIds: [belgium, brussels], online: true }, // online under Brussels
+    { point: [2.35, 48.85], ancestorIds: [france], online: false }, // outside the subtree
+  ]
+
+  it('groups located events by the direct child whose subtree holds them', () => {
+    const { byChild } = partitionUnder(subtree, belgium, [antwerpen, brussels])
+
+    // Attribution follows ancestry to the one direct child, not the terminal region.
+    expect(byChild.get(antwerpen)).toHaveLength(1)
+    expect(byChild.get(brussels)).toHaveLength(2)
+  })
+
+  it('classifies online by the flag, not geometry; placeless offline stays located', () => {
+    const { direct, online } = partitionUnder(subtree, belgium, [antwerpen, brussels])
+
+    // The coordinate-less *offline* event (point: null) is located → `direct`, not online.
+    expect(direct).toEqual([{ point: null, ancestorIds: [belgium], online: false }])
+    // Only the eventType-online event rolls up, though it shares a null point with `direct`.
+    expect(online).toEqual([{ point: null, ancestorIds: [belgium, brussels], online: true }])
+  })
+
+  it('excludes events outside the region subtree', () => {
+    const { byChild, direct, online } = partitionUnder(subtree, belgium, [antwerpen, brussels])
+    const kept = [...byChild.values()].flat().length + direct.length + online.length
+
+    // Five of six events fall under Belgium; the France event is dropped entirely.
+    expect(kept).toBe(5)
+  })
+
+  it('puts every located event in `direct` for a childless leaf, online rolled up', () => {
+    // Brussels as a leaf (no child ids): its two located events hang off `direct`,
+    // its online event rolls up — the same split a city/center view renders.
+    const { byChild, direct, online } = partitionUnder(subtree, brussels, [])
+
+    expect(byChild.size).toBe(0)
+    expect(direct).toHaveLength(2)
+    expect(online).toHaveLength(1)
   })
 })

--- a/src/lib/shape/hierarchy.ts
+++ b/src/lib/shape/hierarchy.ts
@@ -15,6 +15,13 @@ export type GeoEvent = {
   point: Position | null
   /** Region ids of the event's full ancestry (country → … → city/center), inclusive. */
   ancestorIds: number[]
+  /**
+   * Whether the event is online (`eventType: 'online'`), classified upstream from
+   * the event type — never from geometry, so a coordinate-less *offline* event
+   * still counts as located. Online events belong to no place: they never affect
+   * child cards, counts, or promotion, and surface only via the region roll-up.
+   */
+  online: boolean
 }
 
 type Breadcrumb = { doc?: number | { id: number } | null }
@@ -46,3 +53,52 @@ export const boundsUnder = (events: GeoEvent[], regionId: number): BBox | null =
       .map((event) => event.point)
       .filter((point): point is Position => point !== null),
   )
+
+/** The events under a region, split into the buckets a region view renders. */
+export type RegionPartition<T> = {
+  /** Located events grouped by the direct child whose subtree contains them. */
+  byChild: Map<number, T[]>
+  /** Located events attached to the region itself, below no child. */
+  direct: T[]
+  /** Every online event under the region, for the roll-up (belongs to no child). */
+  online: T[]
+}
+
+/**
+ * Splits the events under `regionId` into its region view's buckets in a single
+ * O(events) pass — replacing a per-child `countUnder` (O(children × events)):
+ *
+ * - `byChild` — located events keyed by the direct child (`childIds`) whose
+ *   subtree holds them; a child with ≥ 2 renders a card, exactly 1 is promoted.
+ * - `direct` — located events hanging off the region itself (for a childless
+ *   leaf, `childIds: []`, this is every located event under it).
+ * - `online` — every online event under the region, surfaced via the roll-up.
+ *
+ * A located event's ancestry meets `childIds` in exactly one place (the hierarchy
+ * is a tree), so its attribution is unambiguous.
+ */
+export const partitionUnder = <T extends GeoEvent>(
+  events: T[],
+  regionId: number,
+  childIds: number[],
+): RegionPartition<T> => {
+  const byChild = new Map<number, T[]>(childIds.map((id) => [id, []]))
+  const direct: T[] = []
+  const online: T[] = []
+
+  for (const event of events) {
+    if (!event.ancestorIds.includes(regionId)) continue
+
+    if (event.online) {
+      online.push(event)
+      continue
+    }
+
+    const childId = event.ancestorIds.find((id) => byChild.has(id))
+    const bucket = childId === undefined ? direct : byChild.get(childId)
+
+    bucket?.push(event)
+  }
+
+  return { byChild, direct, online }
+}

--- a/src/lib/shape/hierarchy.ts
+++ b/src/lib/shape/hierarchy.ts
@@ -69,7 +69,7 @@ export type RegionPartition<T> = {
  * O(events) pass — replacing a per-child `countUnder` (O(children × events)):
  *
  * - `byChild` — located events keyed by the direct child (`childIds`) whose
- *   subtree holds them; a child with ≥ 2 renders a card, exactly 1 is promoted.
+ *   subtree holds them (the caller cards a child from its bucket size).
  * - `direct` — located events hanging off the region itself (for a childless
  *   leaf, `childIds: []`, this is every located event under it).
  * - `online` — every online event under the region, surfaced via the roll-up.

--- a/src/lib/shape/path.test.ts
+++ b/src/lib/shape/path.test.ts
@@ -130,6 +130,20 @@ describe('resolveStack', () => {
     ])
   })
 
+  it('owns /…/online, carrying the parent region slug', () => {
+    expect(resolveStack('/canada/ontario/online')).toEqual([
+      { kind: 'region', slug: 'canada', path: '/canada' },
+      { kind: 'region', slug: 'ontario', path: '/canada/ontario' },
+      { kind: 'online', regionSlug: 'ontario', path: '/canada/ontario/online' },
+    ])
+    // An event opened from the online drawer nests under it.
+    expect(resolveStack('/canada/ontario/online/507').at(-1)).toEqual({
+      kind: 'event',
+      id: 507,
+      path: '/canada/ontario/online/507',
+    })
+  })
+
   it('skips legacy prefixes so a legacy URL is just its terminal entity', () => {
     expect(resolveStack('/events/507')).toEqual([{ kind: 'event', id: 507, path: '/events/507' }])
     expect(resolveStack('/areas/antwerpen')).toEqual([

--- a/src/lib/shape/path.ts
+++ b/src/lib/shape/path.ts
@@ -80,16 +80,17 @@ export const resolvePath = (pathname: string): ResolvedPath => {
 }
 
 /**
- * Words that are never a region slug. `search` / `register` / `share` are our own
- * routed views (a CMS region slug can never silently shadow them — the guard);
- * `events` / `areas` / `regions` / `venues` are legacy URL prefixes that carry no
- * drawer of their own. Kept lowercase; matched case-insensitively.
+ * Words that are never a region slug. `search` / `filters` / `register` / `share` /
+ * `online` are our own routed views (a CMS region slug can never silently shadow them
+ * — the guard); `events` / `areas` / `regions` / `venues` are legacy URL prefixes that
+ * carry no drawer of their own. Kept lowercase; matched case-insensitively.
  */
 export const RESERVED_SLUGS = new Set([
   'search',
   'filters',
   'register',
   'share',
+  'online',
   'events',
   'areas',
   'regions',
@@ -104,6 +105,7 @@ export type StackEntry =
   | { kind: 'event'; id: number; path: string }
   | { kind: 'register'; eventPath: string; path: string }
   | { kind: 'share'; eventPath: string; path: string }
+  | { kind: 'online'; regionSlug: string; path: string }
 
 /**
  * The full ancestor chain for a pathname — one entry per meaningful segment, in
@@ -128,6 +130,8 @@ export const resolveStack = (pathname: string): StackEntry[] => {
     else if (word === 'filters') entries.push({ kind: 'filters', path })
     else if (word === 'register') entries.push({ kind: 'register', eventPath: parentPath, path })
     else if (word === 'share') entries.push({ kind: 'share', eventPath: parentPath, path })
+    else if (word === 'online')
+      entries.push({ kind: 'online', regionSlug: safeDecode(segments[i - 1] ?? ''), path })
     else if (RESERVED_SLUGS.has(word))
       return // legacy prefix (events/areas/…) — no drawer
     else if (/^\d+$/.test(segment)) entries.push({ kind: 'event', id: Number(segment), path })

--- a/src/types/region.test.ts
+++ b/src/types/region.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 import { RegionDocSchema, RegionListItemSchema, RegionSchema } from './region'
 
-import { mockEventSlimList } from '@/mocks/events'
+import { mockEventSlim, mockEventSlimList, mockEventSlimOnline } from '@/mocks/events'
 
 const regionDoc = {
   id: 28,
@@ -40,6 +40,7 @@ const country = {
   webUrl: 'https://atlas.example/belgium',
   subregions: [listItem],
   events: [],
+  onlineEvents: [],
 }
 
 // A center (venue): `events` populated, derived center point.
@@ -55,6 +56,7 @@ const venue = {
   parentPath: '/belgium/flanders/antwerpen',
   subregions: [],
   events: mockEventSlimList,
+  onlineEvents: [],
 }
 
 describe('RegionDocSchema', () => {
@@ -110,6 +112,18 @@ describe('RegionSchema', () => {
 
     expect(parsed.center).toEqual([4.35, 50.85])
     expect(parsed.events).toHaveLength(mockEventSlimList.length)
+  })
+
+  it('rolls up online events disjoint from located events', () => {
+    const parsed = RegionSchema.parse({
+      ...venue,
+      events: [mockEventSlim],
+      onlineEvents: [mockEventSlimOnline],
+    })
+
+    expect(parsed.events.map((event) => event.eventType)).toEqual(['offline'])
+    expect(parsed.onlineEvents).toHaveLength(1)
+    expect(parsed.onlineEvents[0].eventType).toBe('online')
   })
 
   it('allows null bounds and null center', () => {

--- a/src/types/region.ts
+++ b/src/types/region.ts
@@ -35,11 +35,11 @@ export const RegionListItemSchema = z.object({
 export type RegionListItem = z.infer<typeof RegionListItemSchema>
 
 // One derived view-model for every region level. `subregions` lists child regions
-// with ≥ 2 located events (a single-event child is promoted into `events` instead);
-// `events` holds this region's *located* events, and `onlineEvents` rolls up every
-// placeless online event under it. `bounds` frames the map for all levels (online
-// events never contribute); `center` is the derived point a `center` (venue) uses
-// when it has no bounds. `countryCode` is set only for countries.
+// with any located events; `events` holds this region's own *located* events (those
+// under no child — a leaf's whole list), and `onlineEvents` rolls up every placeless
+// online event under it. `bounds` frames the map for all levels (online events never
+// contribute); `center` is the derived point a `center` (venue) uses when it has no
+// bounds. `countryCode` is set only for countries.
 export const RegionSchema = z.object({
   id: z.number(),
   slug: z.string(),
@@ -55,8 +55,8 @@ export const RegionSchema = z.object({
   // Absolute canonical URL (server webUrl) for the page's <link rel="canonical">.
   webUrl: z.string().nullish(),
   subregions: z.array(RegionListItemSchema),
-  // Located events only (promoted single-event children + events directly under the
-  // region); never online — those live in `onlineEvents`. The two sets are disjoint.
+  // This region's own located events (those under no child — a leaf's whole list);
+  // never online — those live in `onlineEvents`. The two sets are disjoint.
   events: z.array(EventSlimSchema),
   // Placeless online events under this region's subtree, rolled up onto every level.
   onlineEvents: z.array(EventSlimSchema),

--- a/src/types/region.ts
+++ b/src/types/region.ts
@@ -34,9 +34,11 @@ export const RegionListItemSchema = z.object({
 })
 export type RegionListItem = z.infer<typeof RegionListItemSchema>
 
-// One derived view-model for every region level. `country`/`region` populate
-// `subregions` (child list); `city`/`center` populate `events`. `bounds` frames
-// the map for all levels; `center` is the derived point a `center` (venue) uses
+// One derived view-model for every region level. `subregions` lists child regions
+// with ≥ 2 located events (a single-event child is promoted into `events` instead);
+// `events` holds this region's *located* events, and `onlineEvents` rolls up every
+// placeless online event under it. `bounds` frames the map for all levels (online
+// events never contribute); `center` is the derived point a `center` (venue) uses
 // when it has no bounds. `countryCode` is set only for countries.
 export const RegionSchema = z.object({
   id: z.number(),
@@ -53,6 +55,10 @@ export const RegionSchema = z.object({
   // Absolute canonical URL (server webUrl) for the page's <link rel="canonical">.
   webUrl: z.string().nullish(),
   subregions: z.array(RegionListItemSchema),
+  // Located events only (promoted single-event children + events directly under the
+  // region); never online — those live in `onlineEvents`. The two sets are disjoint.
   events: z.array(EventSlimSchema),
+  // Placeless online events under this region's subtree, rolled up onto every level.
+  onlineEvents: z.array(EventSlimSchema),
 })
 export type Region = z.infer<typeof RegionSchema>

--- a/src/views/CountriesView/CountriesView.tsx
+++ b/src/views/CountriesView/CountriesView.tsx
@@ -1,19 +1,24 @@
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
 import { CircleFlag } from 'react-circle-flags'
 import { useTranslation } from 'react-i18next'
 
 import { DrawerBody, DrawerHeader } from '@/components/atoms/Drawer'
+import { MonitorIcon } from '@/components/atoms/Icons'
 import { List, RegionCard } from '@/components/molecules'
 import api, { clientQuery } from '@/config/api'
 import atlasAuth from '@/config/api/auth'
+import { GEOJSON_STALE_TIME } from '@/config/query-client'
 import { useLocale } from '@/hooks/use-locale'
 import { useMapController } from '@/hooks/use-map-controller'
 import { useWidgetMode } from '@/config/mode'
+import { DEFAULT_FILTERS, filtersToParams } from '@/lib/shape'
 import { validateWebUrl } from '@/lib/url'
 import { CollapseToggle, FilterButton, SearchField, useFrameOnTop } from '@/views/shared'
 
-// The base view (route `/`): the global country list, with the geocoder + a
+// The base view (route `/`): a leading "Online Classes" entry (into the
+// online-filtered search) then the global country list, with the geocoder + a
 // stacked-list toggle in its header. Rendered as inner content of the persistent
 // drawer (DrawerStack owns the sheet). Handled like every other view — it's simply
 // the one with no parent, so dismissing it collapses the sheet to its peek.
@@ -28,6 +33,20 @@ export function CountriesView() {
     queryFn: () => api.getCountries(),
   })
   const { data: client } = useSuspenseQuery(clientQuery(atlasAuth.apiKey))
+
+  // The "Online Classes" entry links to the online-filtered search; its count is
+  // the number of placeless online events in the (already-cached) feed.
+  const { data: geojson } = useQuery({
+    queryKey: ['geojson'],
+    queryFn: () => api.getGeojson(),
+    staleTime: GEOJSON_STALE_TIME,
+  })
+  const onlineCount = useMemo(
+    () =>
+      geojson?.features.filter((feature) => feature.properties.eventType === 'online').length ?? 0,
+    [geojson],
+  )
+  const onlineSearch = `/search?${filtersToParams({ ...DEFAULT_FILTERS, format: 'online' }).toString()}`
 
   // Frame the world view when this view mounts.
   useFrameOnTop(() => frameSearch({}), [frameSearch])
@@ -51,6 +70,13 @@ export function CountriesView() {
       </DrawerHeader>
       <DrawerBody>
         <List>
+          {/* Online classes belong to no country — a leading entry into the
+              online-filtered search rather than a place in the list below. */}
+          {onlineCount > 0 && (
+            <RegionCard count={onlineCount} href={onlineSearch} label={t('online_classes')}>
+              <MonitorIcon className="mr-3 shrink-0 text-2xl" />
+            </RegionCard>
+          )}
           {countries.map((country) => (
             <RegionCard
               key={country.id}

--- a/src/views/CountriesView/CountriesView.tsx
+++ b/src/views/CountriesView/CountriesView.tsx
@@ -5,15 +5,14 @@ import { CircleFlag } from 'react-circle-flags'
 import { useTranslation } from 'react-i18next'
 
 import { DrawerBody, DrawerHeader } from '@/components/atoms/Drawer'
-import { MonitorIcon } from '@/components/atoms/Icons'
-import { List, RegionCard } from '@/components/molecules'
+import { List, OnlineClassesCard, RegionCard } from '@/components/molecules'
 import api, { clientQuery } from '@/config/api'
 import atlasAuth from '@/config/api/auth'
 import { GEOJSON_STALE_TIME } from '@/config/query-client'
 import { useLocale } from '@/hooks/use-locale'
 import { useMapController } from '@/hooks/use-map-controller'
 import { useWidgetMode } from '@/config/mode'
-import { DEFAULT_FILTERS, filtersToParams } from '@/lib/shape'
+import { DEFAULT_FILTERS, filtersToParams, isOnline } from '@/lib/shape'
 import { validateWebUrl } from '@/lib/url'
 import { CollapseToggle, FilterButton, SearchField, useFrameOnTop } from '@/views/shared'
 
@@ -42,8 +41,7 @@ export function CountriesView() {
     staleTime: GEOJSON_STALE_TIME,
   })
   const onlineCount = useMemo(
-    () =>
-      geojson?.features.filter((feature) => feature.properties.eventType === 'online').length ?? 0,
+    () => geojson?.features.filter((feature) => isOnline(feature.properties)).length ?? 0,
     [geojson],
   )
   const onlineSearch = `/search?${filtersToParams({ ...DEFAULT_FILTERS, format: 'online' }).toString()}`
@@ -72,11 +70,7 @@ export function CountriesView() {
         <List>
           {/* Online classes belong to no country — a leading entry into the
               online-filtered search rather than a place in the list below. */}
-          {onlineCount > 0 && (
-            <RegionCard count={onlineCount} href={onlineSearch} label={t('online_classes')}>
-              <MonitorIcon className="mr-3 shrink-0 text-2xl" />
-            </RegionCard>
-          )}
+          {onlineCount > 0 && <OnlineClassesCard count={onlineCount} href={onlineSearch} />}
           {countries.map((country) => (
             <RegionCard
               key={country.id}

--- a/src/views/DrawerStack/DrawerStack.tsx
+++ b/src/views/DrawerStack/DrawerStack.tsx
@@ -24,6 +24,7 @@ import { CountriesView } from '@/views/CountriesView/CountriesView'
 import { SearchView } from '@/views/SearchView/SearchView'
 import { FilterView } from '@/views/FilterView/FilterView'
 import { RegionView } from '@/views/RegionView/RegionView'
+import { OnlineView } from '@/views/OnlineView/OnlineView'
 import { EventView } from '@/views/EventView/EventView'
 import { RegistrationView } from '@/views/RegistrationView/RegistrationView'
 import { ShareView } from '@/views/ShareView/ShareView'
@@ -62,6 +63,8 @@ function TopView({ entry, parentPath }: { entry: StackEntry | null; parentPath: 
       return <FilterView />
     case 'region':
       return <RegionView slug={entry.slug} />
+    case 'online':
+      return <OnlineView path={entry.path} regionSlug={entry.regionSlug} />
     case 'event':
       return <EventView basePath={entry.path} id={entry.id} />
     case 'register':

--- a/src/views/FilterView/FilterView.tsx
+++ b/src/views/FilterView/FilterView.tsx
@@ -8,23 +8,29 @@ import { Button } from '@/components/atoms/Button'
 import { SearchFilters } from '@/components/molecules'
 import api from '@/config/api'
 import { GEOJSON_STALE_TIME } from '@/config/query-client'
-import { useEventFilters, useSearchState } from '@/config/store'
-import { DEFAULT_FILTERS, filtersKey, hasActiveFilters, matchesFilters } from '@/lib/shape'
+import { useEventFilters } from '@/hooks/use-filters'
+import {
+  DEFAULT_FILTERS,
+  filtersKey,
+  filtersToParams,
+  hasActiveFilters,
+  matchesFilters,
+} from '@/lib/shape'
 import { CloseButton } from '@/views/shared'
 
 // The event-filters drawer (route `/filters`, or `/search/filters` when stacked
 // over a search). A normal drawer view — standard header + close chrome and the
 // usual stacking. Filters are NOT applied live: the form edits a local draft.
 // "Apply (N)" (shown only when the draft differs from what's applied) commits the
-// draft to the store — which drives the list + map — and closes the drawer,
-// showing how many events the draft matches. "Clear all" resets everything AND
-// applies + closes. The per-filter clears inside the form stay draft-only.
+// draft into the /search query — the single source of truth that drives the list +
+// map — and closes the drawer, showing how many events the draft matches. "Clear
+// all" resets everything AND applies + closes. The per-filter clears inside the
+// form stay draft-only.
 export function FilterView() {
   const { t } = useTranslation('common')
   const navigate = useNavigate()
   const location = useLocation()
   const applied = useEventFilters()
-  const setFilters = useSearchState((state) => state.setFilters)
 
   // Start from the applied filters; discarded on close unless the user applies.
   const [draft, setDraft] = useState(applied)
@@ -47,12 +53,14 @@ export function FilterView() {
   const hasChanges = filtersKey(draft) !== filtersKey(applied)
   const draftActive = hasActiveFilters(draft)
 
-  // Applying/clearing always shows the results: go to /search (preserving any
-  // search query), even when the drawer was opened over the country list — the
-  // point of applying is to see the filtered events, not return to the countries.
+  // Applying/clearing always shows the results: go to /search with the filters
+  // written into the query (preserving any existing q/bbox/center), even when the
+  // drawer was opened over the country list — the point of applying is to see the
+  // filtered events, not return to the countries.
   const commit = (filters: typeof draft) => {
-    setFilters(filters)
-    navigate({ pathname: '/search', search: location.search })
+    const search = filtersToParams(filters, new URLSearchParams(location.search)).toString()
+
+    navigate({ pathname: '/search', search })
   }
 
   return (

--- a/src/views/OnlineView/OnlineView.tsx
+++ b/src/views/OnlineView/OnlineView.tsx
@@ -1,0 +1,50 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+
+import { DrawerBody, DrawerHeader } from '@/components/atoms/Drawer'
+import { EventCard, List } from '@/components/molecules'
+import api from '@/config/api'
+import { useLocale } from '@/hooks/use-locale'
+import { useMapController } from '@/hooks/use-map-controller'
+import { childRoute } from '@/lib/shape'
+import { CloseButton, useFrameOnTop } from '@/views/shared'
+
+// The online-classes drawer (route `<region-path>/online`): the placeless online
+// events rolled up under a region, listed on their own so the region page's list
+// stays a clean set of places. Reuses the parent region's already-cached data
+// (`['region', slug]`, so navigating here is usually a cache hit) and frames the
+// map to that region — online events have no location of their own. `path` is this
+// drawer's own route, so each event nests under it (dismissing an event returns here).
+export function OnlineView({ regionSlug, path }: { regionSlug: string; path: string }) {
+  const { t } = useTranslation('common')
+  const { regionNames } = useLocale()
+  const { frameRegion } = useMapController()
+
+  const { data: region } = useSuspenseQuery({
+    queryKey: ['region', regionSlug],
+    queryFn: () => api.getRegion(regionSlug),
+  })
+
+  useFrameOnTop(() => frameRegion(region), [region, frameRegion])
+
+  const regionName = (region.countryCode && regionNames.of(region.countryCode)) || region.name
+
+  return (
+    <>
+      <DrawerHeader className="justify-between">
+        <div className="min-w-0">
+          <div className="truncate text-lg font-bold">{t('online_classes')}</div>
+          <div className="truncate text-sm text-gray-11">{regionName}</div>
+        </div>
+        <CloseButton />
+      </DrawerHeader>
+      <DrawerBody>
+        <List>
+          {region.onlineEvents.map((event) => (
+            <EventCard key={event.id} event={{ ...event, path: childRoute(path, event.id) }} />
+          ))}
+        </List>
+      </DrawerBody>
+    </>
+  )
+}

--- a/src/views/OnlineView/index.ts
+++ b/src/views/OnlineView/index.ts
@@ -1,0 +1,1 @@
+export { OnlineView } from './OnlineView'

--- a/src/views/RegionView/RegionView.tsx
+++ b/src/views/RegionView/RegionView.tsx
@@ -13,12 +13,13 @@ import { childRoute } from '@/lib/shape'
 import { validateWebUrl } from '@/lib/url'
 import { CloseButton, useFrameOnTop } from '@/views/shared'
 
-// A region at any level (route `<region-path>`): a leading "Online Classes" card
-// (only when placeless online events roll up under the region) that opens their own
-// drawer (`<region-path>/online`), then the child-region cards, then this region's
-// own located events — so the list stays a clean set of places. Frames the map to
-// the region's bounds when it's the top of the stack. No canonicalization redirect —
-// the URL stays where the user navigated; the canonical tag is standalone-only.
+// A region at any level (route `<region-path>`): child-region cards then this
+// region's located events. A parent with sub-regions leads with an "Online Classes"
+// card (only when online events roll up) that opens their own drawer
+// (`<region-path>/online`), keeping the list a clean set of places; a leaf lists its
+// online events inline, after the located ones. Frames the map to the region's bounds
+// when it's the top of the stack. No canonicalization redirect — the URL stays where
+// the user navigated; the canonical tag is standalone-only.
 export function RegionView({ slug }: { slug: string }) {
   const { t } = useTranslation('common')
   const { regionNames } = useLocale()
@@ -35,6 +36,9 @@ export function RegionView({ slug }: { slug: string }) {
   const header = (region.countryCode && regionNames.of(region.countryCode)) || region.name
   const subheader = region.level === 'city' ? (region.subtitle ?? undefined) : undefined
   const canonicalUrl = validateWebUrl(region.webUrl)
+  // Parents (with sub-region cards) surface their online roll-up behind a dedicated
+  // "Online Classes" card; a leaf lists its online events inline, as before.
+  const showOnlineCard = region.subregions.length > 0 && region.onlineEvents.length > 0
 
   return (
     <>
@@ -53,15 +57,15 @@ export function RegionView({ slug }: { slug: string }) {
       </DrawerHeader>
       <DrawerBody>
         <List>
-          {/* Placeless online classes rolled up under this region open in their own
-              drawer, so the list below stays a clean set of places. */}
-          {region.onlineEvents.length > 0 && (
+          {/* On a parent, the online roll-up opens in its own drawer via this card,
+              keeping the list below a clean set of places. */}
+          {showOnlineCard && (
             <RegionCard
               count={region.onlineEvents.length}
               href={childRoute(region.path, 'online')}
               label={t('online_classes')}
             >
-              <MonitorIcon className="mr-3 shrink-0 text-2xl text-primary" />
+              <MonitorIcon className="mr-3 shrink-0 text-2xl" />
             </RegionCard>
           )}
           {/* Region ids and event ids come from independent sequences but share one
@@ -78,6 +82,11 @@ export function RegionView({ slug }: { slug: string }) {
           {region.events.map((event) => (
             <EventCard key={`event-${event.id}`} event={event} />
           ))}
+          {/* A leaf has no card — its online events list inline, after the located ones. */}
+          {!showOnlineCard &&
+            region.onlineEvents.map((event) => (
+              <EventCard key={`online-${event.id}`} event={event} />
+            ))}
         </List>
       </DrawerBody>
     </>

--- a/src/views/RegionView/RegionView.tsx
+++ b/src/views/RegionView/RegionView.tsx
@@ -1,22 +1,26 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
+import { useTranslation } from 'react-i18next'
 
 import { DrawerBody, DrawerHeader } from '@/components/atoms/Drawer'
 import { EventCard, List, RegionCard } from '@/components/molecules'
+import { MonitorIcon } from '@/components/atoms/Icons'
 import api from '@/config/api'
 import { useLocale } from '@/hooks/use-locale'
 import { useMapController } from '@/hooks/use-map-controller'
 import { useWidgetMode } from '@/config/mode'
+import { childRoute } from '@/lib/shape'
 import { validateWebUrl } from '@/lib/url'
 import { CloseButton, useFrameOnTop } from '@/views/shared'
 
-// A region at any level (route `<region-path>`): one list of child-region cards,
-// then this region's located events, then the placeless online events rolled up
-// under it (plain concatenation, no section headers — EventCard differentiates
-// online). Frames the map to the region's bounds when it's the top of the stack.
-// No canonicalization redirect — the URL stays where the user navigated; the
-// canonical tag is standalone-only.
+// A region at any level (route `<region-path>`): a leading "Online Classes" card
+// (only when placeless online events roll up under the region) that opens their own
+// drawer (`<region-path>/online`), then the child-region cards, then this region's
+// own located events — so the list stays a clean set of places. Frames the map to
+// the region's bounds when it's the top of the stack. No canonicalization redirect —
+// the URL stays where the user navigated; the canonical tag is standalone-only.
 export function RegionView({ slug }: { slug: string }) {
+  const { t } = useTranslation('common')
   const { regionNames } = useLocale()
   const { standalone } = useWidgetMode()
   const { frameRegion } = useMapController()
@@ -49,8 +53,19 @@ export function RegionView({ slug }: { slug: string }) {
       </DrawerHeader>
       <DrawerBody>
         <List>
-          {/* Region ids and event ids come from independent sequences, so all three
-              maps land in one List — namespace the keys so they can't collide. */}
+          {/* Placeless online classes rolled up under this region open in their own
+              drawer, so the list below stays a clean set of places. */}
+          {region.onlineEvents.length > 0 && (
+            <RegionCard
+              count={region.onlineEvents.length}
+              href={childRoute(region.path, 'online')}
+              label={t('online_classes')}
+            >
+              <MonitorIcon className="mr-3 shrink-0 text-2xl text-primary" />
+            </RegionCard>
+          )}
+          {/* Region ids and event ids come from independent sequences but share one
+              List — namespace the keys so they can't collide. */}
           {region.subregions.map((child) => (
             <RegionCard
               key={`region-${child.id}`}
@@ -62,10 +77,6 @@ export function RegionView({ slug }: { slug: string }) {
           ))}
           {region.events.map((event) => (
             <EventCard key={`event-${event.id}`} event={event} />
-          ))}
-          {/* Placeless online events under this region, rolled up at the end. */}
-          {region.onlineEvents.map((event) => (
-            <EventCard key={`online-${event.id}`} event={event} />
           ))}
         </List>
       </DrawerBody>

--- a/src/views/RegionView/RegionView.tsx
+++ b/src/views/RegionView/RegionView.tsx
@@ -49,9 +49,11 @@ export function RegionView({ slug }: { slug: string }) {
       </DrawerHeader>
       <DrawerBody>
         <List>
+          {/* Region ids and event ids come from independent sequences, so all three
+              maps land in one List — namespace the keys so they can't collide. */}
           {region.subregions.map((child) => (
             <RegionCard
-              key={child.id}
+              key={`region-${child.id}`}
               count={child.eventCount}
               href={child.path}
               label={child.name}
@@ -59,11 +61,11 @@ export function RegionView({ slug }: { slug: string }) {
             />
           ))}
           {region.events.map((event) => (
-            <EventCard key={event.id} event={event} />
+            <EventCard key={`event-${event.id}`} event={event} />
           ))}
           {/* Placeless online events under this region, rolled up at the end. */}
           {region.onlineEvents.map((event) => (
-            <EventCard key={event.id} event={event} />
+            <EventCard key={`online-${event.id}`} event={event} />
           ))}
         </List>
       </DrawerBody>

--- a/src/views/RegionView/RegionView.tsx
+++ b/src/views/RegionView/RegionView.tsx
@@ -1,10 +1,8 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
-import { useTranslation } from 'react-i18next'
 
 import { DrawerBody, DrawerHeader } from '@/components/atoms/Drawer'
-import { EventCard, List, RegionCard } from '@/components/molecules'
-import { MonitorIcon } from '@/components/atoms/Icons'
+import { EventCard, List, OnlineClassesCard, RegionCard } from '@/components/molecules'
 import api from '@/config/api'
 import { useLocale } from '@/hooks/use-locale'
 import { useMapController } from '@/hooks/use-map-controller'
@@ -21,7 +19,6 @@ import { CloseButton, useFrameOnTop } from '@/views/shared'
 // when it's the top of the stack. No canonicalization redirect — the URL stays where
 // the user navigated; the canonical tag is standalone-only.
 export function RegionView({ slug }: { slug: string }) {
-  const { t } = useTranslation('common')
   const { regionNames } = useLocale()
   const { standalone } = useWidgetMode()
   const { frameRegion } = useMapController()
@@ -60,13 +57,10 @@ export function RegionView({ slug }: { slug: string }) {
           {/* On a parent, the online roll-up opens in its own drawer via this card,
               keeping the list below a clean set of places. */}
           {showOnlineCard && (
-            <RegionCard
+            <OnlineClassesCard
               count={region.onlineEvents.length}
               href={childRoute(region.path, 'online')}
-              label={t('online_classes')}
-            >
-              <MonitorIcon className="mr-3 shrink-0 text-2xl" />
-            </RegionCard>
+            />
           )}
           {/* Region ids and event ids come from independent sequences but share one
               List — namespace the keys so they can't collide. */}

--- a/src/views/RegionView/RegionView.tsx
+++ b/src/views/RegionView/RegionView.tsx
@@ -10,10 +10,12 @@ import { useWidgetMode } from '@/config/mode'
 import { validateWebUrl } from '@/lib/url'
 import { CloseButton, useFrameOnTop } from '@/views/shared'
 
-// A region at any level (route `<region-path>`): one list of child regions then
-// child events (plain concatenation, no section headers). Frames the map to the
-// region's bounds when it's the top of the stack. No canonicalization redirect —
-// the URL stays where the user navigated; the canonical tag is standalone-only.
+// A region at any level (route `<region-path>`): one list of child-region cards,
+// then this region's located events, then the placeless online events rolled up
+// under it (plain concatenation, no section headers — EventCard differentiates
+// online). Frames the map to the region's bounds when it's the top of the stack.
+// No canonicalization redirect — the URL stays where the user navigated; the
+// canonical tag is standalone-only.
 export function RegionView({ slug }: { slug: string }) {
   const { regionNames } = useLocale()
   const { standalone } = useWidgetMode()
@@ -57,6 +59,10 @@ export function RegionView({ slug }: { slug: string }) {
             />
           ))}
           {region.events.map((event) => (
+            <EventCard key={event.id} event={event} />
+          ))}
+          {/* Placeless online events under this region, rolled up at the end. */}
+          {region.onlineEvents.map((event) => (
             <EventCard key={event.id} event={event} />
           ))}
         </List>

--- a/src/views/shared.tsx
+++ b/src/views/shared.tsx
@@ -14,7 +14,7 @@ import { Button, IconButton } from '@/components/atoms/Button'
 import { CloseIcon, FilterIcon, ListIcon } from '@/components/atoms/Icons'
 import { MapSearch } from '@/components/organisms/Mapbox/MapSearch'
 import api from '@/config/api'
-import { useSearchState } from '@/config/store'
+import { useEventFilters } from '@/hooks/use-filters'
 import { activeFilterCount, resolvePath } from '@/lib/shape'
 
 // Collapse/expand + dismiss control for the sheet, provided by DrawerStack. Views
@@ -82,7 +82,7 @@ export function FilterButton() {
   const { t } = useTranslation('common')
   const navigate = useNavigate()
   const location = useLocation()
-  const count = useSearchState((state) => activeFilterCount(state))
+  const count = activeFilterCount(useEventFilters())
 
   const label = count > 0 ? `${t('filters.title')} (${count})` : t('filters.title')
   const to = `${location.pathname === '/' ? '' : location.pathname}/filters`

--- a/src/views/shared.tsx
+++ b/src/views/shared.tsx
@@ -3,7 +3,7 @@ import type { GeocodingFeature } from '@mapbox/search-js-core'
 import type { DependencyList } from 'react'
 
 import { createContext, useCallback, useContext, useEffect } from 'react'
-import { useLocation, useNavigate } from 'react-router'
+import { useLocation, useNavigate, useSearchParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { useSuspenseQuery } from '@tanstack/react-query'
 
@@ -15,7 +15,7 @@ import { CloseIcon, FilterIcon, ListIcon } from '@/components/atoms/Icons'
 import { MapSearch } from '@/components/organisms/Mapbox/MapSearch'
 import api from '@/config/api'
 import { useEventFilters } from '@/hooks/use-filters'
-import { activeFilterCount, resolvePath } from '@/lib/shape'
+import { activeFilterCount, filtersFromParams, filtersToParams, resolvePath } from '@/lib/shape'
 
 // Collapse/expand + dismiss control for the sheet, provided by DrawerStack. Views
 // use it for their close / list-toggle buttons, so those act on the ONE persistent
@@ -112,10 +112,13 @@ export function FilterButton() {
 // used to live in the removed SearchBar.
 export function SearchField() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   const handleSelect = useCallback(
     (value: GeocodingFeature) => {
-      const params = new URLSearchParams()
+      // Preserve the active filters (URL-only now) while resetting the searched
+      // location — searching a new place shouldn't silently clear the filters.
+      const params = filtersToParams(filtersFromParams(searchParams))
 
       params.set('q', value.properties.full_address ?? '')
       if (value.properties.bbox) params.set('bbox', value.properties.bbox.toString())
@@ -125,7 +128,7 @@ export function SearchField() {
       )
       navigate(`/search?${params.toString()}`)
     },
-    [navigate],
+    [navigate, searchParams],
   )
 
   return (

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
     include: ['**/*.{test,spec}.{ts,tsx}'],
     // Co-located specs live under src/; smoke specs hit the network and run via
     // their own config — keep them (and build output) out of the unit lane.
-    exclude: ['node_modules', 'dist', 'build', '.ladle', 'tests/smoke/**'],
+    // `.claude/worktrees` holds gitignored git worktrees (each a full checkout with
+    // its own node_modules) — never scan those, or the lane runs duplicate/foreign specs.
+    exclude: ['node_modules', 'dist', 'build', '.ladle', 'tests/smoke/**', '.claude/worktrees/**'],
   },
 })


### PR DESCRIPTION
## Summary

Two connected improvements, both derived client-side from the already-cached `['geojson']` feed — **no SahajCloud change**:

- **Online classes are surfaced properly.** Placeless online events (`eventType: 'online'`, no coordinates) roll up under every region. On a **parent** region they sit behind a dedicated **"Online Classes" card** (→ `<region>/online` drawer); on a **leaf** they list inline after the located events. **CountriesView** leads with a global "Online Classes" card (total online count) that links to the online-filtered search. Region lists stay a clean set of *places*, and online events stop hiding on their own leaf page.
- **Search filters are now the URL query — linkable & shareable.** The applied filters moved out of a zustand slice into the URL (`?format=online&cadence=WEEKLY&days=1,3&time=9,17&langs=en,fr`), the single source of truth. The map, the results list, the active-filter pills, and the FilterButton badge all read the same URL; FilterView Apply and the pills write it. This is what makes the CountriesView card (`/search?format=online`) work.

Also: region cards derive from the located/online split (a subregion's badge counts **located** events; a subtree that's online-only still renders), and RegionCard rows are a touch more compact.

## Changes

- **`src/lib/shape/hierarchy.ts`** — `partitionUnder(events, regionId, childIds)` → `{ byChild, direct, online }`, one O(events) pass; `GeoEvent` gains an `online` flag (classified by `eventType`, never geometry).
- **`src/lib/shape/event.ts`** — `byNextOccurrence` comparator (undated last, NaN-safe) for ordering the roll-up.
- **`src/lib/shape/path.ts`** — `online` reserved slug + StackEntry + `resolveStack` case (carries the parent region slug); events opened from the drawer nest under it.
- **`src/config/api/fetch.ts`** — `getRegion` partitions once (card ≥1-located children, roll up online); `eventCount` stays total. `getCountries` unchanged.
- **`src/types/region.ts`** — `RegionSchema` gains `onlineEvents` (disjoint from `events`).
- **`src/views/OnlineView/`** (new) — the online-classes drawer; reuses the parent region's cached `['region', slug]` data, frames the map to that region.
- **`src/views/RegionView/`, `CountriesView`, `DrawerStack`** — render the cards / dispatch the drawer.
- **`src/lib/shape/filters.ts`** — `filtersToParams` / `filtersFromParams` (compact, defaults omitted, malformed-tolerant).
- **`src/hooks/use-filters.ts`** (new) — `useEventFilters` (URL read) + `useSetFilters` (URL write, reads current filters from the setState `prev`). Consumers (`Map`, `EventsList`, `ActiveFilterPills`, `FilterView`, `shared.tsx`, the geocoder) rewired; the zustand filter slice is removed.
- **`src/components/molecules/OnlineClassesCard/`** (new) — the shared MonitorIcon + label card, used by both RegionView and CountriesView.

## Verification

- Lint ✓ · Types ✓ · Unit lane ✓ (162 tests) · Build ✓ (`.claude/skills/pr-prep/check.sh --full`).
- Added coverage: `partitionUnder`, `byNextOccurrence`, `getRegion` (carded/online-only/leaf split), `RegionSchema` parse, `resolveStack('/…/online')`, and the filter URL round-trip / malformed-fallback.

## Manual / visual verification

Driven in the running widget against the local seed (487 events, 28 online):

1. **Roll-up** — `/italy` (parent): "Online Classes" card → `/italy/online` drawer lists the 3 Rome-hosted online events (nested paths, map framed on Italy). `/canada/ontario/toronto` (leaf): its online event lists inline.
2. **CountriesView card** — "Online Classes 28" → `/search?format=online`.
3. **Filters ↔ URL** — deep-link `/search?format=online` → "Online" pill + badge (1) + 28 online-only results; removing the pill drops the param; FilterView Apply (Online + Weekly) → `/search?format=online&cadence=WEEKLY`, badge (2), two pills.

## Notes for reviewer

- **#37 was "blocked by #32"** (an open perf spike). It was designed to ship on today's breadcrumb ancestry — `partitionUnder` is agnostic to where child/ancestor ids come from — so #32 can later swap the source without touching the logic. Confirmed with the maintainer before implementing.
- **Filter behavior change:** an active filter narrows the **map pins** only while its params are in the URL (on `/search`), not globally as you browse regions. Region event lists were already unfiltered, so this is the only visible change. (Chosen deliberately — the URL-as-source model is fully linkable with no store↔URL sync bugs.)
- **⚠️ Design question — count consistency.** Country-list badges and a region's own `eventCount` count **located + online** (per the original #37 spec: "getCountries unchanged, total badges"), while child-region cards count **located only**. Now that online has its own "Online Classes" card, online events are counted in both the country badge *and* that card. Left as-specced, but worth deciding whether country badges should become located-only for consistency (a UX call, so not changed here).
- **Two unrelated fixes are bundled** (each its own commit): `fix(scripts): typecheck error in add-locale-key setNested` — `main` was merged red from #42, which every branch inherits; fixing it here unblocks this PR's CI. And `test(config): keep .claude/worktrees out of the unit lane` — a gitignored worktree was polluting the local unit lane (no CI effect).

## Review passes (all over the full branch diff, via subagents)

- **Simplify** (4 agents): extracted the shared `OnlineClassesCard` molecule, reused `isOnline`, simplified `useEventFilters`, fixed stale comments.
- **Code-review** (high): fixed one **regression** — the geocoder dropped active filters (they live only in the URL now); hardened `useSetFilters` against a concurrent-change clobber; fixed docstrings.
- **Security**: **no risk introduced** — URL filter values are enum/numeric-clamped and only feed client-side `matchesFilters` + re-serialization (never an href or a request); all routes are safe site-relative paths; no new HTML sinks, data exposure, or deps. (Added a `languages` cap for parser symmetry.)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
