### PR TITLE
feat(widget): add sahajcloud live preview for region and event views

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@hookform/resolvers": "^3.10.0",
     "@mapbox/search-js-core": "1.0.0-beta.24",
     "@mapbox/search-js-react": "1.0.0-beta.24",
+    "@payloadcms/live-preview-react": "^3.86.0",
     "@r2wc/react-to-web-component": "^2.0.4",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-checkbox": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@mapbox/search-js-react':
         specifier: 1.0.0-beta.24
         version: 1.0.0-beta.24(mapbox-gl@3.9.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@payloadcms/live-preview-react':
+        specifier: ^3.86.0
+        version: 3.86.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@r2wc/react-to-web-component':
         specifier: ^2.0.4
         version: 2.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -757,6 +760,15 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@payloadcms/live-preview-react@3.86.0':
+    resolution: {integrity: sha512-xsepFDuyw+0yYKUWFxAPl1xaUA6JXDU4rsPItMJJWYOYuwVy/5ZSkZAz5m/itoXbLkczDsq7gJbvnr2BnysrEw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.1 || ^19.1.2 || ^19.2.1
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.1 || ^19.1.2 || ^19.2.1
+
+  '@payloadcms/live-preview@3.86.0':
+    resolution: {integrity: sha512-JjLFRCRKgKmDD+lUoXUaaovwpsoeTlwFTXOnCJfV9PMKeZodet1oVlezKNlg1U+Ygq+tI5NOAzEVRtXykfVmtg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5345,6 +5357,14 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@oxc-project/types@0.139.0': {}
+
+  '@payloadcms/live-preview-react@3.86.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@payloadcms/live-preview': 3.86.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@payloadcms/live-preview@3.86.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import type { PaletteRoles } from '@/config/theme/palette'
 
-import { type RefObject, Suspense, useEffect, useMemo, useRef } from 'react'
+import { type RefObject, Suspense, lazy, useEffect, useMemo, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import { Helmet } from 'react-helmet-async'
 import * as Fathom from 'fathom-client'
@@ -22,6 +22,12 @@ import { NoopMapControllerProvider, RealMapControllerProvider } from '@/hooks/us
 import '@/styles/globals.css'
 import '@/config/i18n'
 import i18n from '@/config/i18n'
+
+// Preview mode is admin-only and lazy-loaded, so `@payloadcms/live-preview-react` and
+// the controller land in their own chunk — zero cost to normal standalone/embedded use.
+const PreviewController = lazy(() =>
+  import('@/components/preview/PreviewController').then((m) => ({ default: m.PreviewController })),
+)
 
 // ===== APP ===== //
 
@@ -139,6 +145,11 @@ function AppShell({ apiKey, defaultLocale, standalone, hasMap, preview }: AppShe
       <Helmet>
         <meta content={locale} property="og:locale" />
       </Helmet>
+      {preview && (
+        <Suspense fallback={null}>
+          <PreviewController />
+        </Suspense>
+      )}
       {hasMap ? (
         <MapProvider>
           {/* Inline fixed/inset so the map always fills the viewport behind the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,10 @@ type AppProps = {
   standalone?: boolean
   // Render the Mapbox canvas (default true). map=false omits the whole map subtree.
   hasMap?: boolean
+  // SahajCloud live-preview mode (default false). Set only by the /preview boot
+  // (main.tsx); lazy-mounts <PreviewController> and inerts navigation — zero cost
+  // to normal standalone/embedded use.
+  preview?: boolean
 }
 
 export default function App({
@@ -47,6 +51,7 @@ export default function App({
   themeRootRef,
   standalone = false,
   hasMap = true,
+  preview = false,
 }: AppProps) {
   return (
     <Providers>
@@ -57,6 +62,7 @@ export default function App({
               apiKey={apiKey}
               defaultLocale={defaultLocale}
               hasMap={hasMap}
+              preview={preview}
               standalone={standalone}
             />
           </ErrorBoundary>
@@ -73,9 +79,10 @@ type AppShellProps = {
   defaultLocale?: string | null
   standalone: boolean
   hasMap: boolean
+  preview: boolean
 }
 
-function AppShell({ apiKey, defaultLocale, standalone, hasMap }: AppShellProps) {
+function AppShell({ apiKey, defaultLocale, standalone, hasMap, preview }: AppShellProps) {
   if (!apiKey) throw new Error('Missing api key.')
 
   const { data: client } = useSuspenseQuery(clientQuery(apiKey))
@@ -128,7 +135,7 @@ function AppShell({ apiKey, defaultLocale, standalone, hasMap }: AppShellProps) 
   }, [location.pathname, fathomEnabled, primaryDomain])
 
   return (
-    <WidgetModeContext.Provider value={{ standalone, hasMap }}>
+    <WidgetModeContext.Provider value={{ standalone, hasMap, preview }}>
       <Helmet>
         <meta content={locale} property="og:locale" />
       </Helmet>

--- a/src/components/organisms/RegistrationForm/RegistrationForm.tsx
+++ b/src/components/organisms/RegistrationForm/RegistrationForm.tsx
@@ -19,6 +19,7 @@ import { Checkbox } from '@/components/atoms/Checkbox'
 import { Select, SelectItem } from '@/components/atoms/Select'
 import { ShareContent } from '@/components/molecules/ShareContent'
 import api from '@/config/api'
+import { useWidgetMode } from '@/config/mode'
 import { useRegistrationDraft } from '@/config/store'
 import { Registration, RegistrationSchema } from '@/types'
 import { useLocale } from '@/hooks/use-locale'
@@ -54,6 +55,9 @@ export function RegistrationForm({
 }: RegistrationFormProps) {
   const [submitted, setSubmitted] = useState(false)
   const { t } = useTranslation('events')
+  // In live preview the event is a draft — previewing must never create a real
+  // registration, so the submit is disabled and mutate() is short-circuited.
+  const { preview } = useWidgetMode()
 
   // Restore any in-progress values for this event once, so a drawer remount (e.g.
   // the md-crossing direction remount) can't drop a half-filled form.
@@ -94,7 +98,9 @@ export function RegistrationForm({
   return (
     <form
       className="mx-auto flex w-full max-w-md flex-col gap-3"
-      onSubmit={handleSubmit((data) => mutation.mutate(data))}
+      onSubmit={handleSubmit((data) => {
+        if (!preview) mutation.mutate(data)
+      })}
     >
       {submitted ? (
         <div className="flex flex-col gap-3 text-center">
@@ -144,7 +150,13 @@ export function RegistrationForm({
             <Button disabled={mutation.isPending} variant="flat" onClick={onClose}>
               {t('registration.cancel')}
             </Button>
-            <Button color="primary" isLoading={mutation.isPending} type="submit" variant="flat">
+            <Button
+              color="primary"
+              disabled={preview}
+              isLoading={mutation.isPending}
+              type="submit"
+              variant="flat"
+            >
               {t('registration.submit')}
             </Button>
           </>

--- a/src/components/preview/PreviewController.tsx
+++ b/src/components/preview/PreviewController.tsx
@@ -9,7 +9,7 @@ import api from '@/config/api'
 import { regionRoute, shapeEventDoc } from '@/config/api/fetch'
 import preview from '@/config/preview'
 import { allowedPreviewPaths, mergePreviewData, shouldBlockPreviewLink } from '@/lib/preview'
-import { safePath } from '@/lib/shape'
+import { isCanonicalPath, safePath } from '@/lib/shape'
 import { EventDocSchema } from '@/types'
 
 // The CMS admin posts live doc updates from the SahajCloud origin; the hook validates
@@ -60,7 +60,12 @@ function usePreviewRouteLock(previewPath: string, collection: 'events' | 'region
   const { pathname } = useLocation()
 
   useEffect(() => {
-    if (!allowedPreviewPaths(previewPath, collection).includes(pathname)) {
+    // Compare decoded: `pathname` is percent-encoded for accented slugs (e.g.
+    // `/li%C3%A8ge/...`) while the allowed set is decoded (built from webPath), so a raw
+    // `includes` would miss and snap every accented-slug preview back on each navigation.
+    const allowed = allowedPreviewPaths(previewPath, collection)
+
+    if (!allowed.some((path) => isCanonicalPath(pathname, path))) {
       navigate(previewPath, { replace: true })
     }
   }, [pathname, previewPath, collection, navigate])
@@ -168,12 +173,28 @@ function PreviewFallback() {
 }
 
 /**
+ * Pin event/region query freshness while previewing. The controller seeds and live-
+ * overlays ['event', id] / ['region', slug] via setQueryData; without this the global
+ * staleTime of 0 lets a drawer's suspense query background-refetch on remount (e.g. after
+ * closing register/share) and stomp unsaved live edits with the last-saved doc.
+ */
+function usePinnedPreviewQueries(): void {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    queryClient.setQueryDefaults(['event'], { staleTime: Infinity })
+    queryClient.setQueryDefaults(['region'], { staleTime: Infinity })
+  }, [queryClient])
+}
+
+/**
  * Live-preview controller (issue #40). Mounted only in preview mode (lazy, from
  * AppShell), it renders no drawer of its own — it drives the drawer cache + map camera
  * from the live doc and inerts navigation. Dispatches on the previewed collection.
  */
 export function PreviewController() {
   usePreviewLinkGuard()
+  usePinnedPreviewQueries()
 
   const id = preview.id ? Number(preview.id) : NaN
 

--- a/src/components/preview/PreviewController.tsx
+++ b/src/components/preview/PreviewController.tsx
@@ -7,7 +7,7 @@ import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 
 import api from '@/config/api'
 import { shapeEventDoc } from '@/config/api/fetch'
-import preview, { PREVIEW_PATH } from '@/config/preview'
+import preview from '@/config/preview'
 import { allowedPreviewPaths, mergePreviewData, shouldBlockPreviewLink } from '@/lib/preview'
 import { safePath } from '@/lib/shape'
 import { EventDocSchema } from '@/types'
@@ -48,15 +48,18 @@ function usePreviewLinkGuard(): void {
 /**
  * Route lock: keep the preview pinned to the previewed doc. If navigation lands
  * outside the allowed set — a dismissed drawer stranding on a parent, a button-driven
- * route change — snap back to `previewPath`. `/preview` itself is skipped: the boot
- * effect owns that first transition.
+ * route change — snap back to `previewPath`. This is the single navigation authority:
+ * from the `/preview` boot route (never in the allowed set) it performs the initial hop
+ * to the doc, then keeps the preview pinned. Being conditional, re-running on an already-
+ * allowed path is a no-op — so it never fights a legit register/share drawer, even as
+ * react-router recreates `navigate` on each navigation (an unconditional boot effect
+ * with `navigate` in its deps would snap register/share straight back).
  */
 function usePreviewRouteLock(previewPath: string, collection: 'events' | 'regions'): void {
   const navigate = useNavigate()
   const { pathname } = useLocation()
 
   useEffect(() => {
-    if (pathname === PREVIEW_PATH) return
     if (!allowedPreviewPaths(previewPath, collection).includes(pathname)) {
       navigate(previewPath, { replace: true })
     }
@@ -67,7 +70,6 @@ function usePreviewRouteLock(previewPath: string, collection: 'events' | 'region
 
 function EventLivePreview({ initialDoc }: { initialDoc: EventDoc }) {
   const queryClient = useQueryClient()
-  const navigate = useNavigate()
   const lastGood = useRef(initialDoc)
 
   const { data: liveDoc } = useLivePreview<EventDoc>({
@@ -81,7 +83,7 @@ function EventLivePreview({ initialDoc }: { initialDoc: EventDoc }) {
   // Live: merge each incoming doc onto the last good one (keeping collapsed relations),
   // re-shape, and inject into the drawer's cache. safeParse keeps the last good doc
   // when a mid-edit form state is transiently invalid. Runs on mount too (liveDoc
-  // starts as initialDoc), which seeds the cache before the boot navigation lands.
+  // starts as initialDoc), seeding the cache before the route lock's boot hop lands.
   useEffect(() => {
     const parsed = EventDocSchema.safeParse(mergePreviewData(lastGood.current, liveDoc))
 
@@ -91,12 +93,8 @@ function EventLivePreview({ initialDoc }: { initialDoc: EventDoc }) {
     queryClient.setQueryData(['event', parsed.data.id], shapeEventDoc(parsed.data))
   }, [liveDoc, queryClient])
 
-  // Boot once: navigate to the event's canonical path — the normal resolveStack /
-  // DrawerStack machinery then renders map + drawer from the seeded cache.
-  useEffect(() => {
-    navigate(previewPath, { replace: true })
-  }, [previewPath, navigate])
-
+  // The route lock performs the initial /preview -> event hop, then pins it — the normal
+  // resolveStack / DrawerStack machinery renders map + drawer from the seeded cache.
   usePreviewRouteLock(previewPath, 'events')
 
   return null
@@ -115,7 +113,6 @@ function EventPreview({ id }: { id: number }) {
 
 function RegionLivePreview({ initialDoc }: { initialDoc: RegionDoc }) {
   const queryClient = useQueryClient()
-  const navigate = useNavigate()
 
   const { data: liveDoc } = useLivePreview<RegionDoc>({
     initialData: initialDoc,
@@ -125,11 +122,6 @@ function RegionLivePreview({ initialDoc }: { initialDoc: RegionDoc }) {
 
   const { slug } = initialDoc
   const previewPath = safePath(initialDoc.webPath) ?? `/${slug}`
-
-  // Boot once: navigate to the region; the normal getRegion(slug) fills ['region', slug].
-  useEffect(() => {
-    navigate(previewPath, { replace: true })
-  }, [previewPath, navigate])
 
   // Live: regions have no drafts, so only editable scalars can change — overlay them
   // onto the cached shaped Region (counts/bounds/lists are geojson-derived and can't
@@ -147,6 +139,8 @@ function RegionLivePreview({ initialDoc }: { initialDoc: RegionDoc }) {
     })
   }, [liveDoc, slug, queryClient])
 
+  // The route lock performs the initial /preview -> region hop (the normal getRegion(slug)
+  // then fills ['region', slug]) and pins it thereafter.
   usePreviewRouteLock(previewPath, 'regions')
 
   return null

--- a/src/components/preview/PreviewController.tsx
+++ b/src/components/preview/PreviewController.tsx
@@ -1,0 +1,191 @@
+import type { EventDoc, Region, RegionDoc } from '@/types'
+
+import { useEffect, useRef } from 'react'
+import { useLivePreview } from '@payloadcms/live-preview-react'
+import { useLocation, useNavigate } from 'react-router'
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+
+import api from '@/config/api'
+import { shapeEventDoc } from '@/config/api/fetch'
+import preview, { PREVIEW_PATH } from '@/config/preview'
+import { allowedPreviewPaths, mergePreviewData, shouldBlockPreviewLink } from '@/lib/preview'
+import { safePath } from '@/lib/shape'
+import { EventDocSchema } from '@/types'
+
+// The CMS admin posts live doc updates from the SahajCloud origin; the hook validates
+// message origins against it and re-populates changed relations there.
+const SERVER_URL = import.meta.env.VITE_SAHAJCLOUD_URL
+
+/**
+ * Capture-phase link guard: inert every `<a>` in the preview except a same-page
+ * `#hash`, so a card/description/CTA link can't navigate off the previewed doc.
+ * Register/Share are `<button>`s, not anchors, so they stay live. Ported from
+ * WeMeditateWeb's `usePreviewLinkGuard` — capture phase + `stopPropagation` so it runs
+ * before react-router's own click handler, and `auxclick` covers middle-click.
+ */
+function usePreviewLinkGuard(): void {
+  useEffect(() => {
+    const block = (event: MouseEvent) => {
+      if (!(event.target instanceof Element)) return
+      const anchor = event.target.closest('a')
+
+      if (!anchor || !shouldBlockPreviewLink(anchor.getAttribute('href'))) return
+
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    window.addEventListener('click', block, true)
+    window.addEventListener('auxclick', block, true)
+
+    return () => {
+      window.removeEventListener('click', block, true)
+      window.removeEventListener('auxclick', block, true)
+    }
+  }, [])
+}
+
+/**
+ * Route lock: keep the preview pinned to the previewed doc. If navigation lands
+ * outside the allowed set — a dismissed drawer stranding on a parent, a button-driven
+ * route change — snap back to `previewPath`. `/preview` itself is skipped: the boot
+ * effect owns that first transition.
+ */
+function usePreviewRouteLock(previewPath: string, collection: 'events' | 'regions'): void {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    if (pathname === PREVIEW_PATH) return
+    if (!allowedPreviewPaths(previewPath, collection).includes(pathname)) {
+      navigate(previewPath, { replace: true })
+    }
+  }, [pathname, previewPath, collection, navigate])
+}
+
+// ── Event preview ────────────────────────────────────────────────────────────────
+
+function EventLivePreview({ initialDoc }: { initialDoc: EventDoc }) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const lastGood = useRef(initialDoc)
+
+  const { data: liveDoc } = useLivePreview<EventDoc>({
+    initialData: initialDoc,
+    serverURL: SERVER_URL,
+    depth: 1,
+  })
+
+  const previewPath = safePath(initialDoc.webPath) ?? `/${initialDoc.id}`
+
+  // Live: merge each incoming doc onto the last good one (keeping collapsed relations),
+  // re-shape, and inject into the drawer's cache. safeParse keeps the last good doc
+  // when a mid-edit form state is transiently invalid. Runs on mount too (liveDoc
+  // starts as initialDoc), which seeds the cache before the boot navigation lands.
+  useEffect(() => {
+    const parsed = EventDocSchema.safeParse(mergePreviewData(lastGood.current, liveDoc))
+
+    if (!parsed.success) return
+
+    lastGood.current = parsed.data
+    queryClient.setQueryData(['event', parsed.data.id], shapeEventDoc(parsed.data))
+  }, [liveDoc, queryClient])
+
+  // Boot once: navigate to the event's canonical path — the normal resolveStack /
+  // DrawerStack machinery then renders map + drawer from the seeded cache.
+  useEffect(() => {
+    navigate(previewPath, { replace: true })
+  }, [previewPath, navigate])
+
+  usePreviewRouteLock(previewPath, 'events')
+
+  return null
+}
+
+function EventPreview({ id }: { id: number }) {
+  const { data: doc } = useSuspenseQuery({
+    queryKey: ['preview-event-doc', id],
+    queryFn: () => api.getEventDoc(id),
+  })
+
+  return <EventLivePreview initialDoc={doc} />
+}
+
+// ── Region preview ───────────────────────────────────────────────────────────────
+
+function RegionLivePreview({ initialDoc }: { initialDoc: RegionDoc }) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const { data: liveDoc } = useLivePreview<RegionDoc>({
+    initialData: initialDoc,
+    serverURL: SERVER_URL,
+    depth: 1,
+  })
+
+  const { slug } = initialDoc
+  const previewPath = safePath(initialDoc.webPath) ?? `/${slug}`
+
+  // Boot once: navigate to the region; the normal getRegion(slug) fills ['region', slug].
+  useEffect(() => {
+    navigate(previewPath, { replace: true })
+  }, [previewPath, navigate])
+
+  // Live: regions have no drafts, so only editable scalars can change — overlay them
+  // onto the cached shaped Region (counts/bounds/lists are geojson-derived and can't
+  // move from a form edit). Skips until the region read has populated the cache.
+  useEffect(() => {
+    const cached = queryClient.getQueryData<Region>(['region', slug])
+
+    if (!cached) return
+
+    queryClient.setQueryData<Region>(['region', slug], {
+      ...cached,
+      name: liveDoc.name ?? cached.name,
+      subtitle: liveDoc.subtitle,
+      level: liveDoc.level,
+    })
+  }, [liveDoc, slug, queryClient])
+
+  usePreviewRouteLock(previewPath, 'regions')
+
+  return null
+}
+
+function RegionPreview({ id }: { id: number }) {
+  const { data: doc } = useSuspenseQuery({
+    queryKey: ['preview-region-doc', id],
+    queryFn: () => api.getRegionDocById(id),
+  })
+
+  return <RegionLivePreview initialDoc={doc} />
+}
+
+// A brand-new unsaved doc has no id (standard Payload limitation): show a hint instead
+// of crashing on the fetch.
+function PreviewFallback() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6 text-center">
+      <p className="rounded-medium bg-background/90 px-4 py-3 text-sm text-gray-11 shadow-medium">
+        Save this document to preview it.
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Live-preview controller (issue #40). Mounted only in preview mode (lazy, from
+ * AppShell), it renders no drawer of its own — it drives the drawer cache + map camera
+ * from the live doc and inerts navigation. Dispatches on the previewed collection.
+ */
+export function PreviewController() {
+  usePreviewLinkGuard()
+
+  const id = preview.id ? Number(preview.id) : NaN
+
+  if (!preview.id || Number.isNaN(id)) return <PreviewFallback />
+  if (preview.collection === 'events') return <EventPreview id={id} />
+  if (preview.collection === 'regions') return <RegionPreview id={id} />
+
+  return <PreviewFallback />
+}

--- a/src/components/preview/PreviewController.tsx
+++ b/src/components/preview/PreviewController.tsx
@@ -6,7 +6,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 
 import api from '@/config/api'
-import { shapeEventDoc } from '@/config/api/fetch'
+import { regionRoute, shapeEventDoc } from '@/config/api/fetch'
 import preview from '@/config/preview'
 import { allowedPreviewPaths, mergePreviewData, shouldBlockPreviewLink } from '@/lib/preview'
 import { safePath } from '@/lib/shape'
@@ -121,7 +121,7 @@ function RegionLivePreview({ initialDoc }: { initialDoc: RegionDoc }) {
   })
 
   const { slug } = initialDoc
-  const previewPath = safePath(initialDoc.webPath) ?? `/${slug}`
+  const previewPath = regionRoute(initialDoc)
 
   // Live: regions have no drafts, so only editable scalars can change — overlay them
   // onto the cached shaped Region (counts/bounds/lists are geojson-derived and can't

--- a/src/config/api/client.ts
+++ b/src/config/api/client.ts
@@ -4,6 +4,7 @@ import qs from 'qs'
 import atlasAuth from './auth'
 
 import i18n from '@/config/i18n'
+import preview, { PREVIEW_SECRET_HEADER } from '@/config/preview'
 
 // SahajCloud's 16 localization codes. The widget's i18next language is mapped to
 // the closest of these for the `locale` query param (the geojson endpoint
@@ -56,6 +57,15 @@ client.interceptors.request.use((request) => {
   }
 
   request.params = { ...request.params, locale: toSahajLocale(i18n.resolvedLanguage) }
+
+  // Live preview (issue #40): unlock draft docs and bypass the CMS read cache by
+  // forwarding the preview secret + `draft=true`. Published-only reads ignore `draft`
+  // harmlessly. Gated on an active session with a secret, so normal traffic is
+  // untouched and the secret never rides a non-preview request.
+  if (preview.active && preview.secret) {
+    request.headers[PREVIEW_SECRET_HEADER] = preview.secret
+    request.params.draft = true
+  }
 
   return request
 })

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import atlasAuth from './auth'
 import { toSahajLocale } from './client'
-import api from './fetch'
+import api, { shapeEventDoc } from './fetch'
 
 import preview from '@/config/preview'
 import { queryClient } from '@/config/query-client'
+import { EventDocSchema } from '@/types'
 
 // The shared axios client attaches auth + locale to *every* request via one
 // interceptor (so individual fetchers don't). We mock axios to capture that
@@ -333,5 +334,43 @@ describe('getEvent', () => {
     // Null stays null (the UI skips it); the boundary maps, it doesn't filter.
     expect(event.images[1].url).toBeNull()
     expect(event.images).toHaveLength(2)
+  })
+})
+
+describe('shapeEventDoc', () => {
+  const parse = (overrides: Record<string, unknown> = {}) =>
+    EventDocSchema.parse({
+      id: 13,
+      title: 'Voronezh Class',
+      eventType: 'offline',
+      languages: ['ru'],
+      registrationMode: 'sahaj-atlas',
+      region: { id: 5, slug: 'voronezh', level: 'city' },
+      ...overrides,
+    })
+
+  it('derives path from a safe site-relative webPath', () => {
+    expect(shapeEventDoc(parse({ webPath: '/russia/voronezh/13' })).path).toBe(
+      '/russia/voronezh/13',
+    )
+  })
+
+  it('falls back to /:id when webPath is missing or unsafe', () => {
+    expect(shapeEventDoc(parse()).path).toBe('/13')
+    expect(shapeEventDoc(parse({ webPath: 'https://evil.example' })).path).toBe('/13')
+  })
+
+  it('resolves relative image urls at the boundary, leaving null urls null', () => {
+    const shaped = shapeEventDoc(
+      parse({
+        images: [
+          { id: 2, filename: 'pic.jpg', url: '/api/images/file/pic.jpg', alt: 'Hall' },
+          { id: 3, url: null, alt: 'no file' },
+        ],
+      }),
+    )
+
+    expect(shaped.images[0].url).toMatch(/^https?:\/\/.*\/api\/images\/file\/pic\.jpg$/)
+    expect(shaped.images[1].url).toBeNull()
   })
 })

--- a/src/config/api/fetch.test.ts
+++ b/src/config/api/fetch.test.ts
@@ -4,6 +4,7 @@ import atlasAuth from './auth'
 import { toSahajLocale } from './client'
 import api from './fetch'
 
+import preview from '@/config/preview'
 import { queryClient } from '@/config/query-client'
 
 // The shared axios client attaches auth + locale to *every* request via one
@@ -25,6 +26,9 @@ const interceptor = use.mock.calls[0][0] as (req: AxiosRequest) => AxiosRequest
 
 beforeEach(() => {
   get.mockReset()
+  // Reset the shared preview singleton so only tests that opt in see preview mode.
+  preview.active = false
+  preview.secret = null
   // loadGeojson caches through the shared QueryClient — clear it so each test
   // re-reads the mocked feed rather than a previous test's cached one.
   queryClient.clear()
@@ -52,6 +56,28 @@ describe('api request interceptor', () => {
     atlasAuth.apiKey = null
 
     expect(interceptor({ headers: {} }).headers['Authorization']).toBeUndefined()
+  })
+
+  it('forwards the preview secret header and draft=true for an active preview session', () => {
+    atlasAuth.apiKey = 'k'
+    preview.active = true
+    preview.secret = 'preview-secret-value'
+
+    const request = interceptor({ headers: {}, params: { depth: 1 } })
+
+    expect(request.headers['x-sahajcloud-preview-secret']).toBe('preview-secret-value')
+    expect(request.params).toMatchObject({ depth: 1, draft: true, locale: 'fr' })
+  })
+
+  it('does not forward draft/secret when the session carries no secret', () => {
+    atlasAuth.apiKey = 'k'
+    preview.active = true
+    preview.secret = null
+
+    const request = interceptor({ headers: {} })
+
+    expect(request.headers['x-sahajcloud-preview-secret']).toBeUndefined()
+    expect(request.params?.draft).toBeUndefined()
   })
 })
 

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -133,7 +133,19 @@ const toSlim = (feature: GeoFeature, from?: Position): EventSlim =>
 // The canonical route (`webPath`) is server-computed and virtual, so no depth /
 // breadcrumb populate is needed. Slugs are globally unique, so no `level` filter —
 // the level comes from the doc. Falls back to a flat `/slug` if webPath is absent.
-const regionRoute = (doc: RegionDoc): string => safePath(doc.webPath) ?? `/${doc.slug}`
+export const regionRoute = (doc: RegionDoc): string => safePath(doc.webPath) ?? `/${doc.slug}`
+
+// Scalar fields both raw region reads (by-slug and by-id) select — shared so the two
+// can't drift.
+const REGION_DOC_SELECT = {
+  slug: true,
+  name: true,
+  level: true,
+  subtitle: true,
+  legacyData: true,
+  webPath: true,
+  webUrl: true,
+}
 
 const getRegionDoc = async (slug: string): Promise<RegionDoc> => {
   const response = await client.get('/regions', {
@@ -141,15 +153,7 @@ const getRegionDoc = async (slug: string): Promise<RegionDoc> => {
       where: { slug: { equals: slug } },
       depth: 1,
       limit: 1,
-      select: {
-        slug: true,
-        name: true,
-        level: true,
-        subtitle: true,
-        legacyData: true,
-        webPath: true,
-        webUrl: true,
-      },
+      select: REGION_DOC_SELECT,
     },
   })
 
@@ -167,15 +171,7 @@ const getRegionDocById = async (id: number): Promise<RegionDoc> => {
   const response = await client.get(`/regions/${id}`, {
     params: {
       depth: 1,
-      select: {
-        slug: true,
-        name: true,
-        level: true,
-        subtitle: true,
-        legacyData: true,
-        webPath: true,
-        webUrl: true,
-      },
+      select: REGION_DOC_SELECT,
     },
   })
 

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -160,6 +160,28 @@ const getRegionDoc = async (slug: string): Promise<RegionDoc> => {
   return RegionDocSchema.parse(doc)
 }
 
+// Region by id — the live-preview boot (issue #40) reads the doc directly (the CMS
+// passes an id, not a slug) to derive its canonical path and seed the scalar overlay.
+// Payload's findByID returns the doc itself, not a `docs` list.
+const getRegionDocById = async (id: number): Promise<RegionDoc> => {
+  const response = await client.get(`/regions/${id}`, {
+    params: {
+      depth: 1,
+      select: {
+        slug: true,
+        name: true,
+        level: true,
+        subtitle: true,
+        legacyData: true,
+        webPath: true,
+        webUrl: true,
+      },
+    },
+  })
+
+  return RegionDocSchema.parse(response.data)
+}
+
 const getChildRegions = async (parentId: number): Promise<RegionDoc[]> => {
   const response = await client.get('/regions', {
     params: {
@@ -338,7 +360,7 @@ export const shapeEventDoc = (event: EventDoc): Event => ({
   path: safePath(event.webPath) ?? `/${event.id}`,
 })
 
-const getEvent = async (id: number): Promise<Event> => {
+const getEventDoc = async (id: number): Promise<EventDoc> => {
   const response = await client.get(`/events/${id}`, {
     params: {
       depth: 1,
@@ -371,8 +393,12 @@ const getEvent = async (id: number): Promise<Event> => {
     },
   })
 
-  return shapeEventDoc(EventDocSchema.parse(response.data))
+  return EventDocSchema.parse(response.data)
 }
+
+// Raw fetch stays split out so live preview (issue #40) can seed `useLivePreview`
+// with — and merge live messages against — the unshaped doc, then shape for injection.
+const getEvent = async (id: number): Promise<Event> => shapeEventDoc(await getEventDoc(id))
 
 // ── Widget bootstrap (client config + atlas-wide defaults) ───────────────────────
 
@@ -407,6 +433,8 @@ export default {
   getCountries,
   getEvents,
   getRegion,
+  getRegionDocById,
   getEvent,
+  getEventDoc,
   getClient,
 }

--- a/src/config/api/fetch.ts
+++ b/src/config/api/fetch.ts
@@ -1,5 +1,6 @@
 import type {
   Event,
+  EventDoc,
   EventSlim,
   GeoFeature,
   Geojson,
@@ -322,6 +323,21 @@ const getEvents = async (
 
 // ── Single event detail ─────────────────────────────────────────────────────────
 
+/**
+ * Shape a parsed event doc into the view-model `Event`: resolve image URLs at the data
+ * boundary (SahajCloud serves relative URLs in dev; a null url — a file-less image —
+ * stays null and the UI skips it) and derive a safe `path` from `webPath`. Exported so
+ * live preview (issue #40) reuses the exact same shaping on docs pushed in over the
+ * postMessage stream, not only fetched ones.
+ */
+export const shapeEventDoc = (event: EventDoc): Event => ({
+  ...event,
+  images: event.images.map((image) =>
+    image.url ? { ...image, url: resolveImageUrl(image.url) } : image,
+  ),
+  path: safePath(event.webPath) ?? `/${event.id}`,
+})
+
 const getEvent = async (id: number): Promise<Event> => {
   const response = await client.get(`/events/${id}`, {
     params: {
@@ -355,18 +371,7 @@ const getEvent = async (id: number): Promise<Event> => {
     },
   })
 
-  const event = EventDocSchema.parse(response.data)
-
-  return {
-    ...event,
-    // Resolve image URLs at the data boundary so every consumer gets a ready-to-use
-    // absolute URL (SahajCloud serves relative image URLs in dev) — the same kind of
-    // wire-quirk shaping as `path` below. Null urls stay null; the UI skips them.
-    images: event.images.map((image) =>
-      image.url ? { ...image, url: resolveImageUrl(image.url) } : image,
-    ),
-    path: safePath(event.webPath) ?? `/${event.id}`,
-  }
+  return shapeEventDoc(EventDocSchema.parse(response.data))
 }
 
 // ── Widget bootstrap (client config + atlas-wide defaults) ───────────────────────

--- a/src/config/mode.ts
+++ b/src/config/mode.ts
@@ -1,16 +1,24 @@
 import { createContext, useContext } from 'react'
 
-// The two runtime axes the widget renders under (issue #30):
+// The runtime axes the widget renders under (issue #30):
 //  - `standalone`: the standalone SPA build (BrowserRouter, main.tsx) vs. the
 //    embedded <sahaj-atlas> element (HashRouter). Canonical/og:url tags are only
 //    advertised in the standalone build — the widget's hash URLs are not canonical.
 //  - `hasMap`: whether a Mapbox canvas renders (default true). map=false omits the
 //    whole map subtree; the MapController is then a no-op.
+//  - `preview`: SahajCloud live-preview mode (issue #40). Set only by the /preview
+//    boot (main.tsx); lazy-mounts <PreviewController> and inerts navigation so the
+//    admin can preview draft events/regions. Default false — zero cost otherwise.
 export type WidgetMode = {
   standalone: boolean
   hasMap: boolean
+  preview: boolean
 }
 
-export const WidgetModeContext = createContext<WidgetMode>({ standalone: false, hasMap: true })
+export const WidgetModeContext = createContext<WidgetMode>({
+  standalone: false,
+  hasMap: true,
+  preview: false,
+})
 
 export const useWidgetMode = () => useContext(WidgetModeContext)

--- a/src/config/preview.test.ts
+++ b/src/config/preview.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+
+import { readPreviewParams } from './preview'
+
+describe('readPreviewParams', () => {
+  it('returns null for any route other than /preview', () => {
+    expect(readPreviewParams('/', '')).toBeNull()
+    expect(readPreviewParams('/india/pune/507', '?collection=events&id=507')).toBeNull()
+  })
+
+  it('captures collection/id/secret from the /preview boot URL', () => {
+    expect(readPreviewParams('/preview', '?collection=events&id=507&secret=s3cr3t')).toEqual({
+      active: true,
+      collection: 'events',
+      id: '507',
+      secret: 's3cr3t',
+    })
+  })
+
+  it('accepts the regions collection', () => {
+    expect(readPreviewParams('/preview', '?collection=regions&id=42&secret=x')).toMatchObject({
+      collection: 'regions',
+      id: '42',
+    })
+  })
+
+  it('nulls an unknown or missing collection (unsupported → handled downstream)', () => {
+    expect(readPreviewParams('/preview', '?collection=venues&id=1&secret=x')?.collection).toBeNull()
+    expect(readPreviewParams('/preview', '?id=1&secret=x')?.collection).toBeNull()
+  })
+
+  it('leaves id/secret null when absent but still marks preview active', () => {
+    expect(readPreviewParams('/preview', '')).toEqual({
+      active: true,
+      collection: null,
+      id: null,
+      secret: null,
+    })
+  })
+})

--- a/src/config/preview.ts
+++ b/src/config/preview.ts
@@ -1,0 +1,68 @@
+/**
+ * SahajCloud live-preview session (issue #40).
+ *
+ * When the CMS admin opens Live Preview it loads the standalone Atlas at
+ * `/preview?collection=events|regions&id=<id>&secret=<SAHAJCLOUD_PREVIEW_SECRET>`.
+ * `main.tsx` captures those params here at boot (before React mounts) and scrubs the
+ * secret from the address bar. The request interceptor (`config/api/client.ts`) reads
+ * `secret`/`active` to unlock drafts; `<PreviewController>` reads `collection`/`id` to
+ * boot the drawer. Mirrors `config/api/auth.ts`: a mutable in-memory singleton, never
+ * persisted — the secret lives only in memory, never in the bundle or storage.
+ */
+
+export type PreviewCollection = 'events' | 'regions'
+
+export type PreviewSession = {
+  active: boolean
+  collection: PreviewCollection | null
+  id: string | null
+  secret: string | null
+}
+
+const preview: PreviewSession = {
+  active: false,
+  collection: null,
+  id: null,
+  secret: null,
+}
+
+/** The live-preview boot route. Reserved in `RESERVED_SLUGS` so it never reads as a region. */
+export const PREVIEW_PATH = '/preview'
+
+/**
+ * Parse a boot location into a preview session, or `null` when it isn't the `/preview`
+ * route. Pure (no `window`, no mutation) so it's unit-testable in the node lane. An
+ * unknown/absent `collection` yields a `null` collection — handled downstream as an
+ * unsupported/"save first" fallback rather than a crash.
+ */
+export function readPreviewParams(pathname: string, search: string): PreviewSession | null {
+  if (pathname !== PREVIEW_PATH) return null
+
+  const params = new URLSearchParams(search)
+  const collection = params.get('collection')
+
+  return {
+    active: true,
+    collection: collection === 'events' || collection === 'regions' ? collection : null,
+    id: params.get('id'),
+    secret: params.get('secret'),
+  }
+}
+
+/**
+ * Boot-time capture (`main.tsx`, standalone only). If the URL is the `/preview` route,
+ * populate the singleton and `history.replaceState` the secret out of the address bar —
+ * keeping the `/preview` pathname so it stays inert (no region resolve, no home
+ * redirect). Returns whether preview mode is now active.
+ */
+export function capturePreview(): boolean {
+  const parsed = readPreviewParams(window.location.pathname, window.location.search)
+  if (!parsed) return false
+
+  Object.assign(preview, parsed)
+  window.history.replaceState(null, '', PREVIEW_PATH)
+
+  return true
+}
+
+export default preview

--- a/src/config/preview.ts
+++ b/src/config/preview.ts
@@ -64,6 +64,7 @@ export function readPreviewParams(pathname: string, search: string): PreviewSess
  */
 export function capturePreview(): boolean {
   const parsed = readPreviewParams(window.location.pathname, window.location.search)
+
   if (!parsed) return false
 
   Object.assign(preview, parsed)

--- a/src/config/preview.ts
+++ b/src/config/preview.ts
@@ -30,6 +30,13 @@ const preview: PreviewSession = {
 export const PREVIEW_PATH = '/preview'
 
 /**
+ * Header carrying the live-preview secret to SahajCloud. Must match the CMS's
+ * `PREVIEW_SECRET_HEADER` (`src/lib/utilities/previewSecret.ts`): a request bearing the
+ * valid secret unlocks drafts and is exempt from the client `select`/`populate` gate.
+ */
+export const PREVIEW_SECRET_HEADER = 'x-sahajcloud-preview-secret'
+
+/**
  * Parse a boot location into a preview session, or `null` when it isn't the `/preview`
  * route. Pure (no `window`, no mutation) so it's unit-testable in the node lane. An
  * unknown/absent `collection` yields a `null` collection — handled downstream as an

--- a/src/lib/preview/index.ts
+++ b/src/lib/preview/index.ts
@@ -1,0 +1,2 @@
+export { mergePreviewData } from './merge'
+export { allowedPreviewPaths, shouldBlockPreviewLink } from './navigation'

--- a/src/lib/preview/merge.test.ts
+++ b/src/lib/preview/merge.test.ts
@@ -49,4 +49,13 @@ describe('mergePreviewData', () => {
       schedule: { start: '11', end: '10' },
     })
   })
+
+  it('ignores prototype-polluting keys in the overlay', () => {
+    const base = { title: 'A' }
+    // JSON.parse makes __proto__ a real own key (an object literal would set the prototype).
+    const overlay = JSON.parse('{ "title": "B", "__proto__": { "polluted": true } }')
+
+    expect(mergePreviewData(base, overlay)).toEqual({ title: 'B' })
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
 })

--- a/src/lib/preview/merge.test.ts
+++ b/src/lib/preview/merge.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+
+import { mergePreviewData } from './merge'
+
+describe('mergePreviewData', () => {
+  it('returns the base unchanged when there is no overlay', () => {
+    const base = { title: 'A' }
+
+    expect(mergePreviewData(base, null)).toBe(base)
+    expect(mergePreviewData(base, undefined)).toBe(base)
+  })
+
+  it('keeps a base field the overlay omits, but lets a sibling edit through', () => {
+    type Doc = { title: string; subtitle?: string }
+    const base: Doc = { title: 'A', subtitle: 'keep me' }
+
+    expect(mergePreviewData(base, { title: 'A2' })).toEqual({ title: 'A2', subtitle: 'keep me' })
+  })
+
+  it('keeps a populated relation when the overlay collapses it to the same id', () => {
+    type Doc = { title: string; region: { id: number; name: string } | number }
+    const base: Doc = { title: 'A', region: { id: 5, name: 'Voronezh' } }
+
+    expect(mergePreviewData(base, { title: 'A', region: 5 })).toEqual({
+      title: 'A',
+      region: { id: 5, name: 'Voronezh' },
+    })
+  })
+
+  it('passes a genuinely changed relation id through (the hook re-populates it)', () => {
+    type Doc = { region: { id: number; name: string } | number }
+    const base: Doc = { region: { id: 5, name: 'Voronezh' } }
+
+    expect(mergePreviewData(base, { region: 9 })).toEqual({ region: 9 })
+  })
+
+  it('lets an explicit null clear a field (null is a real edit, not an omission)', () => {
+    type Doc = { subtitle: string | null }
+    const base: Doc = { subtitle: 'A' }
+
+    expect(mergePreviewData(base, { subtitle: null })).toEqual({ subtitle: null })
+  })
+
+  it('recurses into nested groups', () => {
+    type Doc = { schedule: { start: string; end: string } }
+    const base: Doc = { schedule: { start: '9', end: '10' } }
+
+    expect(mergePreviewData(base, { schedule: { start: '11', end: '10' } })).toEqual({
+      schedule: { start: '11', end: '10' },
+    })
+  })
+})

--- a/src/lib/preview/merge.ts
+++ b/src/lib/preview/merge.ts
@@ -33,6 +33,10 @@ function mergeRecursive(
   const result: Record<string, unknown> = { ...base }
 
   for (const key of Object.keys(overlay)) {
+    // Never copy prototype-polluting keys off a wire payload (belt-and-suspenders: the
+    // overlay is origin-validated CMS output and re-validated by zod downstream).
+    if (key === '__proto__' || key === 'constructor') continue
+
     const overlayValue = overlay[key]
     const baseValue = base[key]
 

--- a/src/lib/preview/merge.ts
+++ b/src/lib/preview/merge.ts
@@ -1,0 +1,81 @@
+/**
+ * Sparse-relation merge for live preview (issue #40), ported from WeMeditateWeb's
+ * `mergePreviewData`.
+ *
+ * The PayloadCMS live-preview message stream resends the whole edited doc on every
+ * keystroke but can collapse a populated relationship (`region`, an image) back to its
+ * bare ID. Overlaying such a message directly would blow away the populated object the
+ * initial fetch resolved. This merge keeps the last-known-good populated object
+ * whenever the incoming value is only its ID, while letting every genuine edit — a
+ * changed scalar, a changed/removed relation, an explicit `null` — flow through.
+ */
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date)
+  )
+}
+
+function isRelationReference(value: unknown): value is string | number {
+  return typeof value === 'string' || typeof value === 'number'
+}
+
+function isPopulatedRelation(value: unknown): value is { id: string | number } {
+  return isPlainObject(value) && 'id' in value && isRelationReference(value.id)
+}
+
+function mergeRecursive(
+  base: Record<string, unknown>,
+  overlay: Record<string, unknown>,
+  depth: number,
+  maxDepth: number,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base }
+
+  for (const key of Object.keys(overlay)) {
+    const overlayValue = overlay[key]
+    const baseValue = base[key]
+
+    // `undefined` never clears — an omitted key keeps the base value.
+    if (overlayValue === undefined) continue
+
+    // Keep the populated relationship object when the live message sent only its ID.
+    if (
+      isPopulatedRelation(baseValue) &&
+      isRelationReference(overlayValue) &&
+      baseValue.id === overlayValue
+    ) {
+      result[key] = baseValue
+      continue
+    }
+
+    if (isPlainObject(baseValue) && isPlainObject(overlayValue) && depth < maxDepth) {
+      result[key] = mergeRecursive(baseValue, overlayValue, depth + 1, maxDepth)
+      continue
+    }
+
+    // Real change wins: a changed scalar, a new/changed relation id, or an explicit
+    // null. (A relation whose id genuinely changed flows through as the new id, which
+    // the live-preview hook then re-populates.)
+    result[key] = overlayValue
+  }
+
+  return result
+}
+
+/**
+ * Merge an incoming live-preview `overlay` onto the last-known-good `base`. Returns
+ * `base` unchanged when there's no overlay; otherwise a new object (never mutates
+ * either input). `maxDepth` bounds recursion into nested groups.
+ */
+export function mergePreviewData<T>(base: T, overlay: T | null | undefined, maxDepth = 3): T {
+  if (!overlay) return base
+  if (!isPlainObject(base) || !isPlainObject(overlay)) return overlay ?? base
+
+  return mergeRecursive(
+    base as Record<string, unknown>,
+    overlay as Record<string, unknown>,
+    0,
+    maxDepth,
+  ) as T
+}

--- a/src/lib/preview/navigation.test.ts
+++ b/src/lib/preview/navigation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+
+import { allowedPreviewPaths, shouldBlockPreviewLink } from './navigation'
+
+describe('shouldBlockPreviewLink', () => {
+  it('blocks internal routes, external, mailto, and tel links', () => {
+    expect(shouldBlockPreviewLink('/india/pune')).toBe(true)
+    expect(shouldBlockPreviewLink('/507')).toBe(true)
+    expect(shouldBlockPreviewLink('https://example.com')).toBe(true)
+    expect(shouldBlockPreviewLink('mailto:a@b.com')).toBe(true)
+    expect(shouldBlockPreviewLink('tel:+123')).toBe(true)
+  })
+
+  it('allows same-page hash links (scroll) and ignores missing/empty hrefs', () => {
+    expect(shouldBlockPreviewLink('#section')).toBe(false)
+    expect(shouldBlockPreviewLink('#')).toBe(false)
+    expect(shouldBlockPreviewLink(null)).toBe(false)
+    expect(shouldBlockPreviewLink(undefined)).toBe(false)
+    expect(shouldBlockPreviewLink('')).toBe(false)
+  })
+})
+
+describe('allowedPreviewPaths', () => {
+  it('lets an event stay on its page plus register/share', () => {
+    expect(allowedPreviewPaths('/india/pune/507', 'events')).toEqual([
+      '/india/pune/507',
+      '/india/pune/507/register',
+      '/india/pune/507/share',
+    ])
+  })
+
+  it('pins a region to its own page only', () => {
+    expect(allowedPreviewPaths('/india/pune', 'regions')).toEqual(['/india/pune'])
+  })
+})

--- a/src/lib/preview/navigation.ts
+++ b/src/lib/preview/navigation.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure navigation guards for live preview (issue #40). The React wrappers (a
+ * capture-phase anchor guard + a route lock) live in `<PreviewController>`; these are
+ * the testable predicates behind them.
+ */
+
+/**
+ * Whether an anchor's raw `href` should be inerted in preview. Everything navigates
+ * away from the previewed doc except a same-page `#hash` (a table-of-contents scroll),
+ * and a missing/empty href doesn't navigate at all. Reads the raw attribute, not the
+ * resolved `.href` property, so a bare `#heading` stays detectable.
+ */
+export function shouldBlockPreviewLink(rawHref: string | null | undefined): boolean {
+  if (!rawHref) return false
+  if (rawHref.startsWith('#')) return false
+
+  return true
+}
+
+/**
+ * The routes the preview is allowed to sit on, anchored at the previewed doc's
+ * canonical `previewPath`. An event may also open its register/share drawers; a region
+ * is pinned to its own page. Anything else — a subregion, another event, a dismissed
+ * drawer landing on a parent — snaps back to `previewPath`.
+ */
+export function allowedPreviewPaths(
+  previewPath: string,
+  collection: 'events' | 'regions',
+): string[] {
+  if (collection === 'events') {
+    return [previewPath, `${previewPath}/register`, `${previewPath}/share`]
+  }
+
+  return [previewPath]
+}

--- a/src/lib/preview/navigation.ts
+++ b/src/lib/preview/navigation.ts
@@ -28,6 +28,8 @@ export function allowedPreviewPaths(
   collection: 'events' | 'regions',
 ): string[] {
   if (collection === 'events') {
+    // The event's over-drawers — mirrors the register/share entries resolveStack
+    // appends (src/lib/shape/path.ts). Keep in sync if an event gains another.
     return [previewPath, `${previewPath}/register`, `${previewPath}/share`]
   }
 

--- a/src/lib/shape/path.test.ts
+++ b/src/lib/shape/path.test.ts
@@ -151,6 +151,10 @@ describe('resolveStack', () => {
     ])
   })
 
+  it('skips the /preview boot route (no drawer — PreviewController navigates on)', () => {
+    expect(resolveStack('/preview')).toEqual([])
+  })
+
   it('decodes a region slug but keeps the path encoded (matches the address bar)', () => {
     expect(resolveStack('/belgium/li%C3%A8ge')).toEqual([
       { kind: 'region', slug: 'belgium', path: '/belgium' },

--- a/src/lib/shape/path.ts
+++ b/src/lib/shape/path.ts
@@ -82,8 +82,10 @@ export const resolvePath = (pathname: string): ResolvedPath => {
 /**
  * Words that are never a region slug. `search` / `filters` / `register` / `share` /
  * `online` are our own routed views (a CMS region slug can never silently shadow them
- * — the guard); `events` / `areas` / `regions` / `venues` are legacy URL prefixes that
- * carry no drawer of their own. Kept lowercase; matched case-insensitively.
+ * — the guard); `preview` is the live-preview boot route (issue #40 — captured in
+ * `main.tsx`, carries no drawer of its own); `events` / `areas` / `regions` / `venues`
+ * are legacy URL prefixes that carry no drawer of their own. Kept lowercase; matched
+ * case-insensitively.
  */
 export const RESERVED_SLUGS = new Set([
   'search',
@@ -91,6 +93,7 @@ export const RESERVED_SLUGS = new Set([
   'register',
   'share',
   'online',
+  'preview',
   'events',
   'areas',
   'regions',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter } from 'react-router'
 
 import App from './App.tsx'
 import atlasAuth from './config/api/auth'
+import { capturePreview } from './config/preview'
 import { initTheme } from './hooks/use-theme'
 
 const searchParams = new URLSearchParams(window.location.search)
@@ -15,11 +16,18 @@ if (!atlasAuth.apiKey) {
 // the Mapbox canvas. Default is the full map.
 const hasMap = searchParams.get('map') !== '0' && searchParams.get('map') !== 'false'
 
+// SahajCloud live-preview boot (issue #40): if the URL is `/preview?…`, capture
+// collection/id/secret and scrub the secret from the address bar before React mounts
+// (BrowserRouter snapshots window.location on mount). No-op on every other route, so
+// normal standalone use is unaffected. `key`/`map` above are read first, off the
+// original URL, so scrubbing the query string doesn't drop them.
+const preview = capturePreview()
+
 // Restore the persisted (or default) theme before first paint to avoid a flash.
 initTheme()
 
 ReactDOM.createRoot(document.getElementById('syatlas')!).render(
   <BrowserRouter>
-    <App standalone apiKey={atlasAuth.apiKey} hasMap={hasMap} />
+    <App standalone apiKey={atlasAuth.apiKey} hasMap={hasMap} preview={preview} />
   </BrowserRouter>,
 )


### PR DESCRIPTION
## Summary

Adds PayloadCMS **live preview** for the Region and Event drawers. When an editor opens the Live Preview tab in the SahajCloud admin, the iframe loads the standalone Atlas at `/preview?collection=…&id=…&secret=…`, which renders the full widget — map **and** drawer — for the doc being edited (including unpublished **draft** events) and updates live as they type, without saving or reloading.

- Preview is a new `WidgetMode` axis, set **only** by the standalone `/preview` boot (never by the embedded `<sahaj-atlas>`); the controller is lazy-loaded, so normal standalone/embedded use pays nothing (`@payloadcms/live-preview-react` lands in its own code-split chunk).
- The controller renders **no drawer of its own** — it seeds the existing `['event', id]` / `['region', slug]` query cache from the live doc and drives the URL, then the normal `resolveStack` / `DrawerStack` / `EventView` / `RegionView` machinery renders it. In preview, every link is inert (except same-page `#hash`), navigation is locked to the doc (+ its register/share drawers), and the registration submit is disabled so a draft can't create a real registration.

## Changes

The feature threads through a few seams rather than forking a parallel render path:

- **Boot** — `src/main.tsx` detects `/preview`, captures `collection`/`id`/`secret` into a module singleton (`src/config/preview.ts`, mirroring `config/api/auth.ts`), and `history.replaceState`s the secret out of the address bar before React mounts. `'preview'` joins `RESERVED_SLUGS` so the boot path never resolves as a region.
- **Draft fetch** — the shared request interceptor (`src/config/api/client.ts`) adds `draft=true` + the `x-sahajcloud-preview-secret` header only while a preview session is active.
- **Data shaping** — `getEvent`'s post-parse shaping is extracted into an exported `shapeEventDoc`; `getEventDoc` / `getRegionDocById` fetch the raw docs the controller seeds from and streams edits against.
- **Controller** — `src/components/preview/PreviewController.tsx`: `useLivePreview` → sparse-relation merge (`src/lib/preview/merge.ts`) → re-shape → `setQueryData`; a capture-phase link guard + a conditional route lock (pure predicates in `src/lib/preview/navigation.ts`).

## Verification

- Lint: ✓ (`pnpm lint`, `--max-warnings 0`)
- Types: ✓ (`pnpm typecheck`)
- Tests: ✓ 184 unit tests (`pnpm test:run`) — new coverage for the boot params, the interceptor's draft/secret injection, `shapeEventDoc`, the sparse merge (incl. a prototype-pollution guard), and the navigation predicates.
- Build: ✓ (`pnpm build`) — `PreviewController` is a separate ~4.9 kB chunk, confirming the dependency stays out of the main bundle.

## Manual / visual verification

Driven end-to-end in the browser (Playwright) against a local SahajCloud, previewing real draft/published docs:

- **Draft event** (`/preview?collection=events&id=<draft>`) → boots to the event, renders the full drawer + map framed on the event with a selection pin, for an **unpublished** doc. Secret is stripped from the address bar (`/preview` → `/<id>`, no query).
- **Region** → boots to the region drawer at its bounds.
- **Links inert** — every anchor (directions, `tel:`, attribution) is `preventDefault`ed; the Share/Register `<button>`s stay live.
- **Register** opens the drawer and **stays** there; the submit button is **disabled**; closing returns to the event.
- **Live update** — a synthetic `payload-live-preview` postMessage reaches the controller and the hook posts to the CMS populate endpoint (0 errors).

Runtime verification also **caught a real navigation bug** (opening register/share snapped straight back, because the boot effect had `navigate` in its deps and react-router recreates `navigate` on each navigation) — fixed by folding the boot hop into the conditional route lock (`701be12`).

## Notes for reviewer

- **Production e2e depends on the companion CMS change** (sydevs/SahajCloud#575). The local SahajCloud branch already validates the preview secret + unlocks drafts, but its **CORS `access-control-allow-headers` does not yet list `x-sahajcloud-preview-secret`**, so a browser blocks the cross-origin preview request. I verified the widget end-to-end via a local CORS-forwarding proxy (not committed); the widget side is complete, and the flow works once the CMS allows the header cross-origin.
- **Code review** (high effort, subagent): 2 findings fixed — the route lock compared an encoded pathname against a decoded allowed set (accented slugs would snap back → now `isCanonicalPath`); and the seeded cache could be background-refetched away (→ `staleTime` pinned in preview). 3 dismissed as acceptable for an admin-only, human-paced preview: a first-region-edit-before-fetch-resolves race (narrow window, regions have no drafts), array-relation collapse (the hook re-populates relations server-side; a transient invalid doc keeps last-good via `safeParse`), and `draft=true` riding the geojson feed (scoping it per-request would leak preview-awareness into every fetcher).
- **Security review** (subagent, public-bundle threat model): no Critical/High/Medium. Confirmed the secret never enters the bundle/storage/logs/referrer, the trust boundary holds (a hostile host page can't enable preview), messages are origin-locked, and live data flows through the same zod + DOMPurify pipeline as fetched data. Added a defensive `__proto__`/`constructor` guard to the merge as a nit.
- **Accepted limitations** (per the issue): an unpublished event contributes no cluster dot (the pin + framing still work from the doc's own coordinates); a brand-new unsaved doc (no id) shows a "save first" fallback; a mid-edit new image appears after save + reopen.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
